### PR TITLE
downgrade go elastic client version

### DIFF
--- a/elasticreindexer/go.mod
+++ b/elasticreindexer/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/ElrondNetwork/elrond-go-core v1.0.0
 	github.com/ElrondNetwork/elrond-go-logger v1.0.5
-	github.com/elastic/go-elasticsearch/v7 v7.14.0
+	github.com/elastic/go-elasticsearch/v7 v7.11.0
 	github.com/pelletier/go-toml v1.9.3
 	github.com/tidwall/gjson v1.8.1
 )

--- a/elasticreindexer/go.sum
+++ b/elasticreindexer/go.sum
@@ -22,6 +22,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/denisbrodbeck/machineid v1.0.1 h1:geKr9qtkB876mXguW2X6TU4ZynleN6ezuMSRhl4D7AQ=
 github.com/denisbrodbeck/machineid v1.0.1/go.mod h1:dJUwb7PTidGDeYyUBmXZ2GphQBbjJCrnectwCyxcUSI=
+github.com/elastic/go-elasticsearch/v7 v7.11.0 h1:bv+2GqsVrPdX/ChJqAHAFtWgtGvVJ0icN/WdBGAdNuw=
+github.com/elastic/go-elasticsearch/v7 v7.11.0/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
 github.com/elastic/go-elasticsearch/v7 v7.14.0 h1:extp3jos/rwJn3J+lgbaGlwAgs0TVsIHme00GyNAyX4=
 github.com/elastic/go-elasticsearch/v7 v7.14.0/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=


### PR DESCRIPTION
downgrade elastic search go library to a smaller version as the initial used version has limitations for `build_flavor` instances and did not support managed ES instances