### PR TITLE
added retries for too many requests

### DIFF
--- a/elasticreindexer/elastic/elasticClient.go
+++ b/elasticreindexer/elastic/elasticClient.go
@@ -19,8 +19,6 @@ import (
 
 var log = logger.GetOrCreate("elastic")
 
-const stepDelayBetweenRequests = 1 * time.Second
-
 type esClient struct {
 	client *elasticsearch.Client
 
@@ -204,8 +202,6 @@ func (esc *esClient) iterateScroll(
 		if err != nil {
 			return err
 		}
-
-		time.Sleep(stepDelayBetweenRequests)
 	}
 }
 

--- a/elasticreindexer/elastic/elasticClient.go
+++ b/elasticreindexer/elastic/elasticClient.go
@@ -17,7 +17,10 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-var log = logger.GetOrCreate("elastic")
+var (
+	log                  = logger.GetOrCreate("elastic")
+	httpStatusesForRetry = []int{429, 502, 503, 504}
+)
 
 type esClient struct {
 	client *elasticsearch.Client
@@ -33,7 +36,7 @@ func NewElasticClient(cfg config.ElasticInstanceConfig) (*esClient, error) {
 		Addresses:     []string{cfg.URL},
 		Username:      cfg.Username,
 		Password:      cfg.Password,
-		RetryOnStatus: []int{429, 502, 503, 504},
+		RetryOnStatus: httpStatusesForRetry,
 		RetryBackoff: func(i int) time.Duration {
 			// A simple exponential delay
 			d := time.Duration(math.Exp2(float64(i))) * time.Second


### PR DESCRIPTION
extended Elasticsearch client configuration to include retries for 429 - Too many requests