### PR TITLE
added an overwrite flag when starting the tool

### DIFF
--- a/elasticreindexer/cmd/elasticreindexer/main.go
+++ b/elasticreindexer/cmd/elasticreindexer/main.go
@@ -19,7 +19,7 @@ var (
 	// overwrite defines a bool flag for overwriting destination's data and skipping mappings and aliases checks
 	overwriteFlag = cli.BoolFlag{
 		Name:  "overwrite",
-		Usage: "Overwrite ",
+		Usage: "If set, the reindexing tool will skip the creation of the index and mapping and will overwrite any existing data.",
 	}
 )
 

--- a/elasticreindexer/elastic/elasticClient.go
+++ b/elasticreindexer/elastic/elasticClient.go
@@ -114,9 +114,9 @@ func (esc *esClient) CreateIndexWithMapping(targetIndex string, body *bytes.Buff
 	return nil
 }
 
-// DoesTemplateExist returns true if a template is set to an index
-func (esc *esClient) DoesTemplateExist(index string) bool {
-	res, err := esc.client.Indices.ExistsTemplate([]string{index})
+// DoesIndexExist returns true if an index exists
+func (esc *esClient) DoesIndexExist(index string) bool {
+	res, err := esc.client.Indices.Exists([]string{index})
 	if err != nil {
 		return false
 	}
@@ -172,13 +172,13 @@ func exists(res *esapi.Response, err error) bool {
 		if res != nil && res.Body != nil {
 			err = res.Body.Close()
 			if err != nil {
-				log.Warn("esClient.exists", "could not close body: ", err.Error())
+				log.Warn("esClient.exists: could not close body", "error", err.Error())
 			}
 		}
 	}()
 
 	if err != nil {
-		log.Warn("elasticClient.IndexExists", "could not check index on the elastic nodes:", err.Error())
+		log.Warn("esClient.exists: could not check index on the elastic nodes", "error", err.Error())
 		return false
 	}
 
@@ -188,7 +188,7 @@ func exists(res *esapi.Response, err error) bool {
 	case http.StatusNotFound:
 		return false
 	default:
-		log.Warn("elasticClient.exists", "invalid status code returned by the elastic nodes:", res.StatusCode)
+		log.Warn("esClient.exists: invalid status code returned by the elastic nodes", "error", res.StatusCode)
 		return false
 	}
 }

--- a/elasticreindexer/elastic/elasticClient.go
+++ b/elasticreindexer/elastic/elasticClient.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"math"
 	"net/http"
@@ -132,12 +131,7 @@ func (esc *esClient) DoesAliasExist(alias string) bool {
 		alias,
 	)
 
-	req, err := newRequest(http.MethodHead, aliasRoute, nil)
-	if err != nil {
-		log.Warn("elasticClient.AliasExists",
-			"could not create request objectsMap", err.Error())
-		return false
-	}
+	req := newRequest(http.MethodHead, aliasRoute, nil)
 
 	res, err := esc.client.Transport.Perform(req)
 	if err != nil {
@@ -155,7 +149,7 @@ func (esc *esClient) DoesAliasExist(alias string) bool {
 	return exists(response, nil)
 }
 
-func newRequest(method, path string, body *bytes.Buffer) (*http.Request, error) {
+func newRequest(method, path string, body *bytes.Buffer) *http.Request {
 	r := http.Request{
 		Method:     method,
 		URL:        &url.URL{Path: path},
@@ -170,16 +164,15 @@ func newRequest(method, path string, body *bytes.Buffer) (*http.Request, error) 
 		r.ContentLength = int64(body.Len())
 	}
 
-	return &r, nil
+	return &r
 }
 
 func exists(res *esapi.Response, err error) bool {
 	defer func() {
 		if res != nil && res.Body != nil {
-			_, _ = io.Copy(ioutil.Discard, res.Body)
 			err = res.Body.Close()
 			if err != nil {
-				log.Warn("elasticClient.exists", "could not close body: ", err.Error())
+				log.Warn("esClient.exists", "could not close body: ", err.Error())
 			}
 		}
 	}()

--- a/elasticreindexer/go.mod
+++ b/elasticreindexer/go.mod
@@ -8,4 +8,5 @@ require (
 	github.com/elastic/go-elasticsearch/v7 v7.11.0
 	github.com/pelletier/go-toml v1.9.3
 	github.com/tidwall/gjson v1.8.1
+	github.com/urfave/cli v1.22.5
 )

--- a/elasticreindexer/go.mod
+++ b/elasticreindexer/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/ElrondNetwork/elrond-go-logger v1.0.5
 	github.com/elastic/go-elasticsearch/v7 v7.11.0
 	github.com/pelletier/go-toml v1.9.3
+	github.com/stretchr/testify v1.7.0
 	github.com/tidwall/gjson v1.8.1
 	github.com/urfave/cli v1.22.5
 )

--- a/elasticreindexer/go.sum
+++ b/elasticreindexer/go.sum
@@ -1,3 +1,4 @@
+github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/ElrondNetwork/elrond-go-core v1.0.0 h1:jMgNCQAG2ncOoc+I7u8mQBxbMT/eCuFNSrX1YIKN5v8=
 github.com/ElrondNetwork/elrond-go-core v1.0.0/go.mod h1:FQMem7fFF4+8pQ6lVsBZq6yO+smD0nV23P4bJpmPjTo=
 github.com/ElrondNetwork/elrond-go-logger v1.0.4/go.mod h1:e5D+c97lKUfFdAzFX7rrI2Igl/z4Y0RkKYKWyzprTGk=
@@ -16,6 +17,8 @@ github.com/btcsuite/goleveldb v0.0.0-20160330041536-7834afc9e8cd/go.mod h1:F+uVa
 github.com/btcsuite/snappy-go v0.0.0-20151229074030-0bdef8d06723/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg3lh6TiUghc=
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtEyQwv5/p4Mg4C0fgbePVuGr935/5ddU9Z3TmDRY=
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
+github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
+github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -24,8 +27,6 @@ github.com/denisbrodbeck/machineid v1.0.1 h1:geKr9qtkB876mXguW2X6TU4ZynleN6ezuMS
 github.com/denisbrodbeck/machineid v1.0.1/go.mod h1:dJUwb7PTidGDeYyUBmXZ2GphQBbjJCrnectwCyxcUSI=
 github.com/elastic/go-elasticsearch/v7 v7.11.0 h1:bv+2GqsVrPdX/ChJqAHAFtWgtGvVJ0icN/WdBGAdNuw=
 github.com/elastic/go-elasticsearch/v7 v7.11.0/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
-github.com/elastic/go-elasticsearch/v7 v7.14.0 h1:extp3jos/rwJn3J+lgbaGlwAgs0TVsIHme00GyNAyX4=
-github.com/elastic/go-elasticsearch/v7 v7.14.0/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/go-ole/go-ole v1.2.1/go.mod h1:7FAglXiTm7HKlQRDeOQ6ZNUHidzCWXuZWq/1dTyBNF8=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
@@ -56,8 +57,12 @@ github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCko
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
+github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shirou/gopsutil v0.0.0-20190901111213-e4ec7b275ada/go.mod h1:WWnYX4lzhCH5h/3YBfyVA3VbLYjlMZZAQcW9ojMexNc=
 github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4/go.mod h1:qsXQc7+bwAM3Q1u/4XEfrquwF8Lw7D7y5cD8CuHnfIc=
+github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
+github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
@@ -69,6 +74,8 @@ github.com/tidwall/match v1.0.3 h1:FQUVvBImDutD8wJLN6c5eMzWtjgONK9MwIBCOrUJKeE=
 github.com/tidwall/match v1.0.3/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
 github.com/tidwall/pretty v1.1.0 h1:K3hMW5epkdAVwibsQEfR/7Zj0Qgt4DxtNumTq/VloO8=
 github.com/tidwall/pretty v1.1.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
+github.com/urfave/cli v1.22.5 h1:lNq9sAHXK2qfdI8W+GRItjCEkI+2oR4d+MEHy1CKXoU=
+github.com/urfave/cli v1.22.5/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 golang.org/x/crypto v0.0.0-20170930174604-9419663f5a44/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/elasticreindexer/process/interface.go
+++ b/elasticreindexer/process/interface.go
@@ -12,7 +12,9 @@ type ElasticClientHandler interface {
 		handlerFunc func(responseBytes []byte) error,
 	) error
 	GetCount(index string) (uint64, error)
+	DoesAliasExist(alias string) bool
 	DoBulkRequest(buff *bytes.Buffer, index string) error
+	DoesTemplateExist(index string) bool
 	PutAlias(index string, alias string) error
 	IsInterfaceNil() bool
 }

--- a/elasticreindexer/process/interface.go
+++ b/elasticreindexer/process/interface.go
@@ -14,7 +14,7 @@ type ElasticClientHandler interface {
 	GetCount(index string) (uint64, error)
 	DoesAliasExist(alias string) bool
 	DoBulkRequest(buff *bytes.Buffer, index string) error
-	DoesTemplateExist(index string) bool
+	DoesIndexExist(index string) bool
 	PutAlias(index string, alias string) error
 	IsInterfaceNil() bool
 }

--- a/elasticreindexer/process/mock/elasticClientStub.go
+++ b/elasticreindexer/process/mock/elasticClientStub.go
@@ -1,0 +1,94 @@
+package mock
+
+import (
+	"bytes"
+)
+
+// ElasticClientStub -
+type ElasticClientStub struct {
+	GetMappingCalled                  func(index string) (*bytes.Buffer, error)
+	CreateIndexWithMappingCalled      func(targetIndex string, body *bytes.Buffer) error
+	DoScrollRequestAllDocumentsCalled func(index string, body []byte, handlerFunc func(responseBytes []byte) error) error
+	GetCountCalled                    func(index string) (uint64, error)
+	DoesAliasExistCalled              func(alias string) bool
+	DoBulkRequestCalled               func(buff *bytes.Buffer, index string) error
+	DoesIndexExistCalled              func(index string) bool
+	PutAliasCalled                    func(index string, alias string) error
+}
+
+// GetMapping -
+func (e *ElasticClientStub) GetMapping(index string) (*bytes.Buffer, error) {
+	if e.GetMappingCalled != nil {
+		return e.GetMappingCalled(index)
+	}
+
+	return nil, nil
+}
+
+// CreateIndexWithMapping -
+func (e *ElasticClientStub) CreateIndexWithMapping(targetIndex string, body *bytes.Buffer) error {
+	if e.CreateIndexWithMappingCalled != nil {
+		return e.CreateIndexWithMappingCalled(targetIndex, body)
+	}
+
+	return nil
+}
+
+// DoScrollRequestAllDocuments -
+func (e *ElasticClientStub) DoScrollRequestAllDocuments(index string, body []byte, handlerFunc func(responseBytes []byte) error) error {
+	if e.DoScrollRequestAllDocumentsCalled != nil {
+		return e.DoScrollRequestAllDocumentsCalled(index, body, handlerFunc)
+	}
+
+	return nil
+}
+
+// GetCount -
+func (e *ElasticClientStub) GetCount(index string) (uint64, error) {
+	if e.GetCountCalled != nil {
+		return e.GetCountCalled(index)
+	}
+
+	return 0, nil
+}
+
+// DoesAliasExist -
+func (e *ElasticClientStub) DoesAliasExist(alias string) bool {
+	if e.DoesAliasExistCalled != nil {
+		return e.DoesAliasExistCalled(alias)
+	}
+
+	return false
+}
+
+// DoBulkRequest -
+func (e *ElasticClientStub) DoBulkRequest(buff *bytes.Buffer, index string) error {
+	if e.DoBulkRequestCalled != nil {
+		return e.DoBulkRequestCalled(buff, index)
+	}
+
+	return nil
+}
+
+// DoesIndexExist -
+func (e *ElasticClientStub) DoesIndexExist(index string) bool {
+	if e.DoesIndexExistCalled != nil {
+		return e.DoesIndexExistCalled(index)
+	}
+
+	return false
+}
+
+// PutAlias -
+func (e *ElasticClientStub) PutAlias(index string, alias string) error {
+	if e.PutAliasCalled != nil {
+		return e.PutAliasCalled(index, alias)
+	}
+
+	return nil
+}
+
+// IsInterfaceNil -
+func (e *ElasticClientStub) IsInterfaceNil() bool {
+	return e == nil
+}

--- a/elasticreindexer/process/reindexer.go
+++ b/elasticreindexer/process/reindexer.go
@@ -44,9 +44,9 @@ func newReindexer(sourceElastic ElasticClientHandler, destinationElastic Elastic
 }
 
 // Process will handle the reindexing from source Elastic client to destination Elastic client
-func (r *reindexer) Process() error {
+func (r *reindexer) Process(overwrite bool) error {
 	for _, index := range r.indices {
-		err := r.processIndex(index)
+		err := r.processIndex(index, overwrite)
 		if err != nil {
 			return err
 		}
@@ -55,16 +55,18 @@ func (r *reindexer) Process() error {
 	return nil
 }
 
-func (r *reindexer) processIndex(index string) error {
+func (r *reindexer) processIndex(index string, overwrite bool) error {
 	originalSourceCount, err := r.sourceElastic.GetCount(index)
 	if err != nil {
 		return fmt.Errorf("%w while getting the source count for index %s", err, index)
 	}
 
-	err = r.copyMapping(index)
+	err = r.copyMapping(index, overwrite)
 	if err != nil {
 		return fmt.Errorf("%w while copying the mapping for index %s", err, index)
 	}
+
+	log.Info("starting reindexing", "index", index)
 
 	err = r.reindexData(index)
 	if err != nil {
@@ -76,29 +78,46 @@ func (r *reindexer) processIndex(index string) error {
 		return fmt.Errorf("%w while getting the destination count for index %s", err, index)
 	}
 
-	if destinationCount < originalSourceCount {
-		log.Warn("destination count is not equal to original source count",
-			"destination count", destinationCount,
-			"source count", originalSourceCount)
-	}
+	log.Info("finished indexing for index",
+		"index", index,
+		"original source count", originalSourceCount,
+		"destination count (estimation)", destinationCount)
 
 	return nil
 }
 
-func (r *reindexer) copyMapping(index string) error {
+func (r *reindexer) copyMapping(index string, overwrite bool) error {
 	indexWithSuffix := index + indexSuffix
 
-	sourceMapping, err := r.sourceElastic.GetMapping(index)
-	if err != nil {
-		return fmt.Errorf("copyMapping from source: %w", err)
+	aliasExists := r.destinationElastic.DoesAliasExist(index)
+	if aliasExists && !overwrite {
+		return fmt.Errorf("index with alias %s already exists. Please clean the destination indexer before"+
+			" retrying, or start the tool using --overwrite flag", index)
 	}
 
-	err = r.destinationElastic.CreateIndexWithMapping(indexWithSuffix, sourceMapping)
-	if err != nil {
-		return fmt.Errorf("copyMapping to destination: %w", err)
+	templateExists := r.destinationElastic.DoesTemplateExist(indexWithSuffix)
+	if templateExists && !overwrite {
+		return fmt.Errorf("template for index %s already exists. Please clean the destination indexer before"+
+			" retrying, or start the tool using --overwrite flag", index)
 	}
 
-	return r.destinationElastic.PutAlias(indexWithSuffix, index)
+	if !templateExists && !overwrite {
+		sourceMapping, err := r.sourceElastic.GetMapping(index)
+		if err != nil {
+			return fmt.Errorf("copyMapping from source: %w", err)
+		}
+
+		err = r.destinationElastic.CreateIndexWithMapping(indexWithSuffix, sourceMapping)
+		if err != nil {
+			return fmt.Errorf("copyMapping to destination: %w", err)
+		}
+	}
+
+	if !aliasExists && !overwrite {
+		return r.destinationElastic.PutAlias(indexWithSuffix, index)
+	}
+
+	return nil
 }
 
 func (r *reindexer) reindexData(index string) error {
@@ -136,7 +155,7 @@ func prepareDataForIndexing(responseBytes []byte, index string, count int) ([]*b
 	}
 
 	resultsMap := extractSourceFromEsResponse(esResponse)
-	log.Info("indexing", "index", index, "bulk size", len(resultsMap), "count", count)
+	log.Info("\tindexing", "index", index, "bulk size", len(resultsMap), "count", count)
 	buffSlice := newBufferSlice()
 	for id, source := range resultsMap {
 		meta := []byte(fmt.Sprintf(`{ "index" : { "_id" : "%s" } }%s`, id, "\n"))

--- a/elasticreindexer/process/reindexer.go
+++ b/elasticreindexer/process/reindexer.go
@@ -113,14 +113,11 @@ func (r *reindexer) copyMappingIfNecessary(index string, overwrite bool) error {
 		}
 	}
 
-	if !aliasExists {
-		err := r.destinationElastic.PutAlias(indexWithSuffix, index)
-		if err != nil {
-			return err
-		}
+	if aliasExists {
+		return nil
 	}
 
-	return nil
+	return r.destinationElastic.PutAlias(indexWithSuffix, index)
 }
 
 func (r *reindexer) reindexData(index string) error {

--- a/elasticreindexer/process/reindexer_test.go
+++ b/elasticreindexer/process/reindexer_test.go
@@ -1,0 +1,237 @@
+package process
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/ElrondNetwork/elrond-tools-go/elasticreindexer/process/mock"
+	"github.com/stretchr/testify/require"
+)
+
+const testIndex = "index"
+
+func TestCopyMapping(t *testing.T) {
+	t.Run("no overwrite - no alias - no index => should create",
+		testCopyMappingNoOverwriteShouldCreate)
+	t.Run("no overwrite - no alias - index => should err",
+		testCopyMappingNoOverwriteAliasDoesNotExistsIndexExistsShouldErr)
+	t.Run("no overwrite - alias - no index => should err",
+		testCopyMappingNoOverwriteAliasExistsIndexDoesNotExistShouldErr)
+	t.Run("no overwrite - alias - index => should err",
+		testCopyMappingNoOverwriteAliasAndIndexExistShouldErr)
+
+	t.Run("overwrite - no alias - no index => should copy/create",
+		testCopyMappingOverwriteAliasAndIndexExistShouldCreate)
+	t.Run("overwrite - no alias - index => should create alias",
+		testCopyMappingOverwriteAliasDoesNotExistShouldCreateAlias)
+	t.Run("overwrite - alias - no index => should create alias",
+		testCopyMappingOverwriteAliasExistsIndexDoesNotExistShouldCreateIndex)
+	t.Run("overwrite - alias - index => should not copy/create",
+		testCopyMappingOverwriteAliasAndIndexExistShouldNotCreate)
+}
+
+func testCopyMappingNoOverwriteShouldCreate(t *testing.T) {
+	getMappingCalled := false
+	putAliasCalled := false
+	createIndexCalled := false
+	sourceClient := &mock.ElasticClientStub{
+		GetMappingCalled: func(_ string) (*bytes.Buffer, error) {
+			getMappingCalled = true
+			return nil, nil
+		},
+	}
+
+	destinationClient := &mock.ElasticClientStub{
+		DoesIndexExistCalled: func(_ string) bool {
+			return false
+		},
+		DoesAliasExistCalled: func(_ string) bool {
+			return false
+		},
+		PutAliasCalled: func(_ string, _ string) error {
+			putAliasCalled = true
+			return nil
+		},
+		CreateIndexWithMappingCalled: func(_ string, _ *bytes.Buffer) error {
+			createIndexCalled = true
+			return nil
+		},
+	}
+
+	r, _ := newReindexer(sourceClient, destinationClient, []string{"index"})
+
+	err := r.copyMappingIfNecessary(testIndex, false)
+	require.NoError(t, err)
+	require.True(t, getMappingCalled)
+	require.True(t, putAliasCalled)
+	require.True(t, createIndexCalled)
+}
+
+func testCopyMappingNoOverwriteAliasExistsIndexDoesNotExistShouldErr(t *testing.T) {
+	destinationClient := &mock.ElasticClientStub{
+		DoesAliasExistCalled: func(_ string) bool {
+			return true
+		},
+		DoesIndexExistCalled: func(_ string) bool {
+			return false
+		},
+	}
+
+	r, _ := newReindexer(&mock.ElasticClientStub{}, destinationClient, []string{"index"})
+
+	err := r.copyMappingIfNecessary(testIndex, false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "index with alias index already exists.")
+}
+
+func testCopyMappingNoOverwriteAliasAndIndexExistShouldErr(t *testing.T) {
+	destinationClient := &mock.ElasticClientStub{
+		DoesAliasExistCalled: func(_ string) bool {
+			return true
+		},
+		DoesIndexExistCalled: func(_ string) bool {
+			return true
+		},
+	}
+
+	r, _ := newReindexer(&mock.ElasticClientStub{}, destinationClient, []string{"index"})
+
+	err := r.copyMappingIfNecessary(testIndex, false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "index with alias index already exists.")
+}
+
+func testCopyMappingNoOverwriteAliasDoesNotExistsIndexExistsShouldErr(t *testing.T) {
+	destinationClient := &mock.ElasticClientStub{
+		DoesIndexExistCalled: func(_ string) bool {
+			return true
+		},
+	}
+
+	r, _ := newReindexer(&mock.ElasticClientStub{}, destinationClient, []string{"test-index"})
+
+	err := r.copyMappingIfNecessary("test-index", false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "index test-index already exists.")
+}
+
+func testCopyMappingOverwriteAliasAndIndexExistShouldNotCreate(t *testing.T) {
+	getMappingCalled := false
+	putAliasCalled := false
+	createIndexCalled := false
+	sourceClient := &mock.ElasticClientStub{
+		GetMappingCalled: func(_ string) (*bytes.Buffer, error) {
+			getMappingCalled = true
+			return nil, nil
+		},
+	}
+
+	destinationClient := &mock.ElasticClientStub{
+		DoesIndexExistCalled: func(_ string) bool {
+			return true
+		},
+		DoesAliasExistCalled: func(_ string) bool {
+			return true
+		},
+		PutAliasCalled: func(_ string, _ string) error {
+			putAliasCalled = true
+			return nil
+		},
+		CreateIndexWithMappingCalled: func(_ string, _ *bytes.Buffer) error {
+			createIndexCalled = true
+			return nil
+		},
+	}
+
+	r, _ := newReindexer(sourceClient, destinationClient, []string{"index"})
+
+	err := r.copyMappingIfNecessary(testIndex, true)
+	require.NoError(t, err)
+	require.False(t, getMappingCalled)
+	require.False(t, putAliasCalled)
+	require.False(t, createIndexCalled)
+}
+
+func testCopyMappingOverwriteAliasDoesNotExistShouldCreateAlias(t *testing.T) {
+	putAlias := false
+	createIndexCalled := false
+	destinationClient := &mock.ElasticClientStub{
+		DoesAliasExistCalled: func(_ string) bool {
+			return false
+		},
+		DoesIndexExistCalled: func(_ string) bool {
+			return true
+		},
+		CreateIndexWithMappingCalled: func(_ string, _ *bytes.Buffer) error {
+			createIndexCalled = true
+			return nil
+		},
+		PutAliasCalled: func(_ string, _ string) error {
+			putAlias = true
+			return nil
+		},
+	}
+
+	r, _ := newReindexer(&mock.ElasticClientStub{}, destinationClient, []string{"index"})
+
+	err := r.copyMappingIfNecessary(testIndex, true)
+	require.NoError(t, err)
+	require.True(t, putAlias)
+	require.False(t, createIndexCalled)
+}
+
+func testCopyMappingOverwriteAliasExistsIndexDoesNotExistShouldCreateIndex(t *testing.T) {
+	putAlias := false
+	createIndexCalled := false
+	destinationClient := &mock.ElasticClientStub{
+		DoesAliasExistCalled: func(_ string) bool {
+			return true
+		},
+		DoesIndexExistCalled: func(_ string) bool {
+			return false
+		},
+		CreateIndexWithMappingCalled: func(_ string, _ *bytes.Buffer) error {
+			createIndexCalled = true
+			return nil
+		},
+		PutAliasCalled: func(_ string, _ string) error {
+			putAlias = true
+			return nil
+		},
+	}
+
+	r, _ := newReindexer(&mock.ElasticClientStub{}, destinationClient, []string{"index"})
+
+	err := r.copyMappingIfNecessary(testIndex, true)
+	require.NoError(t, err)
+	require.False(t, putAlias)
+	require.True(t, createIndexCalled)
+}
+
+func testCopyMappingOverwriteAliasAndIndexExistShouldCreate(t *testing.T) {
+	putAlias := false
+	createIndexCalled := false
+	destinationClient := &mock.ElasticClientStub{
+		DoesAliasExistCalled: func(_ string) bool {
+			return false
+		},
+		DoesIndexExistCalled: func(_ string) bool {
+			return false
+		},
+		CreateIndexWithMappingCalled: func(_ string, _ *bytes.Buffer) error {
+			createIndexCalled = true
+			return nil
+		},
+		PutAliasCalled: func(_ string, _ string) error {
+			putAlias = true
+			return nil
+		},
+	}
+
+	r, _ := newReindexer(&mock.ElasticClientStub{}, destinationClient, []string{"index"})
+
+	err := r.copyMappingIfNecessary(testIndex, true)
+	require.NoError(t, err)
+	require.True(t, putAlias)
+	require.True(t, createIndexCalled)
+}


### PR DESCRIPTION
Added a bool flag `--overwrite`. If set, the tool won't fail stating that the alias already exists, but instead, it will write to destination indexer.