### PR TITLE
Export address tokens

### DIFF
--- a/trieTools/accountStorageExporter/main.go
+++ b/trieTools/accountStorageExporter/main.go
@@ -7,41 +7,24 @@ import (
 	"fmt"
 	"io/fs"
 	"io/ioutil"
-	"math/big"
 	"os"
-	"path"
 	"path/filepath"
 
 	"github.com/ElrondNetwork/elrond-go-core/core"
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	"github.com/ElrondNetwork/elrond-go-core/core/pubkeyConverter"
 	logger "github.com/ElrondNetwork/elrond-go-logger"
-	elrondFactory "github.com/ElrondNetwork/elrond-go/cmd/node/factory"
 	"github.com/ElrondNetwork/elrond-go/common"
-	commonDisabled "github.com/ElrondNetwork/elrond-go/common/disabled"
-	"github.com/ElrondNetwork/elrond-go/common/logging"
-	"github.com/ElrondNetwork/elrond-go/epochStart/notifier"
 	"github.com/ElrondNetwork/elrond-go/state"
-	stateFactory "github.com/ElrondNetwork/elrond-go/state/factory"
-	"github.com/ElrondNetwork/elrond-go/state/storagePruningManager/disabled"
-	dbRemoverDisabled "github.com/ElrondNetwork/elrond-go/storage/databaseremover/disabled"
-	"github.com/ElrondNetwork/elrond-go/storage/factory"
-	"github.com/ElrondNetwork/elrond-go/storage/pruning"
-	"github.com/ElrondNetwork/elrond-go/testscommon"
-	"github.com/ElrondNetwork/elrond-go/trie"
 	"github.com/ElrondNetwork/elrond-tools-go/trieTools/accountStorageExporter/config"
 	"github.com/ElrondNetwork/elrond-tools-go/trieTools/trieToolsCommon"
-	"github.com/ElrondNetwork/elrond-tools-go/trieTools/trieToolsCommon/components"
 	"github.com/urfave/cli"
 )
 
 const (
-	defaultLogsPath      = "logs"
-	logFilePrefix        = "account-storage-exporter"
-	maxTrieLevelInMemory = 5
-	rootHashLength       = 32
-	addressLength        = 32
-	maxDirs              = 100
+	logFilePrefix  = "account-storage-exporter"
+	rootHashLength = 32
+	addressLength  = 32
 )
 
 func main() {
@@ -73,7 +56,7 @@ func main() {
 func startProcess(c *cli.Context) error {
 	flagsConfig := getFlagsConfig(c)
 
-	_, errLogger := attachFileLogger(log, flagsConfig)
+	_, errLogger := trieToolsCommon.AttachFileLogger(log, logFilePrefix, flagsConfig.ContextFlagsConfig)
 	if errLogger != nil {
 		return errLogger
 	}
@@ -93,7 +76,7 @@ func startProcess(c *cli.Context) error {
 		return fmt.Errorf("wrong root hash length: expected %d, got %d", rootHashLength, len(rootHash))
 	}
 
-	maxDBValue, err := getMaxDBValue(filepath.Join(flagsConfig.WorkingDir, flagsConfig.DbDir))
+	maxDBValue, err := trieToolsCommon.GetMaxDBValue(filepath.Join(flagsConfig.WorkingDir, flagsConfig.DbDir), log)
 	if err != nil {
 		return err
 	}
@@ -103,103 +86,13 @@ func startProcess(c *cli.Context) error {
 	return exportStorage(flagsConfig.Address, flagsConfig, rootHash, maxDBValue)
 }
 
-func attachFileLogger(log logger.Logger, flagsConfig config.ContextFlagsConfigAddr) (elrondFactory.FileLoggingHandler, error) {
-	var fileLogging elrondFactory.FileLoggingHandler
-	var err error
-	if flagsConfig.SaveLogFile {
-		fileLogging, err = logging.NewFileLogging(logging.ArgsFileLogging{
-			WorkingDir:      flagsConfig.WorkingDir,
-			DefaultLogsPath: defaultLogsPath,
-			LogFilePrefix:   logFilePrefix,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("%w creating a log file", err)
-		}
-	}
-
-	err = logger.SetDisplayByteSlice(logger.ToHex)
-	log.LogIfError(err)
-	logger.ToggleLoggerName(flagsConfig.EnableLogName)
-	logLevelFlagValue := flagsConfig.LogLevel
-	err = logger.SetLogLevel(logLevelFlagValue)
-	if err != nil {
-		return nil, err
-	}
-
-	if flagsConfig.DisableAnsiColor {
-		err = logger.RemoveLogObserver(os.Stdout)
-		if err != nil {
-			return nil, err
-		}
-
-		err = logger.AddLogObserver(os.Stdout, &logger.PlainFormatter{})
-		if err != nil {
-			return nil, err
-		}
-	}
-	log.Trace("logger updated", "level", logLevelFlagValue, "disable ANSI color", flagsConfig.DisableAnsiColor)
-
-	return fileLogging, nil
-}
-
-func getMaxDBValue(parentDir string) (int, error) {
-	contents, err := ioutil.ReadDir(parentDir)
-	if err != nil {
-		return 0, err
-	}
-
-	directories := make([]string, 0)
-	for _, c := range contents {
-		if !c.IsDir() {
-			continue
-		}
-
-		_, ok := big.NewInt(0).SetString(c.Name(), 10)
-		if !ok {
-			log.Debug("DB directory found that will not be taken into account", "name", c.Name())
-			continue
-		}
-
-		directories = append(directories, c.Name())
-	}
-
-	numDirs := 0
-	for i := 0; i < maxDirs; i++ {
-		expectedDir := fmt.Sprintf("%d", i)
-		if !contains(directories, expectedDir) {
-			break
-		}
-
-		numDirs++
-	}
-
-	if numDirs == 0 {
-		return 0, fmt.Errorf("missing ordered directories in %s, like 0, 1 and so on", parentDir)
-	}
-	if numDirs != len(directories) {
-		return 0, fmt.Errorf("unordered directories in %s, like 0, 1 and so on", parentDir)
-	}
-
-	return numDirs - 1, nil
-}
-
-func contains(haystack []string, needle string) bool {
-	for _, h := range haystack {
-		if h == needle {
-			return true
-		}
-	}
-
-	return false
-}
-
 func exportStorage(address string, flags config.ContextFlagsConfigAddr, mainRootHash []byte, maxDBValue int) error {
 	addressConverter, err := pubkeyConverter.NewBech32PubkeyConverter(addressLength, log)
 	if err != nil {
 		return err
 	}
 
-	tr, err := getTrie(flags, maxDBValue)
+	tr, err := trieToolsCommon.GetTrie(flags.ContextFlagsConfig, maxDBValue)
 	if err != nil {
 		return err
 	}
@@ -209,7 +102,7 @@ func exportStorage(address string, flags config.ContextFlagsConfigAddr, mainRoot
 		log.LogIfError(errNotCritical)
 	}()
 
-	accDb, err := newAccountsAdapter(tr)
+	accDb, err := trieToolsCommon.NewAccountsAdapter(tr)
 	if err != nil {
 		return err
 	}
@@ -274,56 +167,4 @@ func exportStorage(address string, flags config.ContextFlagsConfigAddr, mainRoot
 	log.Info("key-value map", "value", keyValueMap)
 
 	return nil
-}
-
-func getTrie(flags config.ContextFlagsConfigAddr, maxDBValue int) (common.Trie, error) {
-	localDbConfig := dbConfig // copy
-	localDbConfig.FilePath = path.Join(flags.WorkingDir, flags.DbDir)
-
-	dbPath := path.Join(flags.WorkingDir, flags.DbDir)
-	args := &pruning.StorerArgs{
-		Identifier:                "",
-		ShardCoordinator:          testscommon.NewMultiShardsCoordinatorMock(1),
-		CacheConf:                 cacheConfig,
-		PathManager:               components.NewSimplePathManager(dbPath),
-		DbPath:                    "",
-		PersisterFactory:          factory.NewPersisterFactory(localDbConfig),
-		Notifier:                  notifier.NewManualEpochStartNotifier(),
-		OldDataCleanerProvider:    &testscommon.OldDataCleanerProviderStub{},
-		CustomDatabaseRemover:     dbRemoverDisabled.NewDisabledCustomDatabaseRemover(),
-		MaxBatchSize:              45000,
-		NumOfEpochsToKeep:         uint32(maxDBValue) + 1,
-		NumOfActivePersisters:     uint32(maxDBValue) + 1,
-		StartingEpoch:             uint32(maxDBValue),
-		PruningEnabled:            true,
-		EnabledDbLookupExtensions: false,
-	}
-
-	db, err := pruning.NewTriePruningStorer(args)
-	if err != nil {
-		return nil, err
-	}
-
-	tsm, err := trie.NewTrieStorageManagerWithoutPruning(db)
-	if err != nil {
-		return nil, err
-	}
-
-	return trie.NewTrie(tsm, trieToolsCommon.Marshaller, trieToolsCommon.Hasher, maxTrieLevelInMemory)
-}
-
-func newAccountsAdapter(trie common.Trie) (state.AccountsAdapter, error) {
-	accCreator := stateFactory.NewAccountCreator()
-	storagePruningManager := disabled.NewDisabledStoragePruningManager()
-	accountsAdapter, err := state.NewAccountsDB(state.ArgsAccountsDB{
-		Trie:                  trie,
-		Hasher:                trieToolsCommon.Hasher,
-		Marshaller:            trieToolsCommon.Marshaller,
-		AccountFactory:        accCreator,
-		StoragePruningManager: storagePruningManager,
-		ProcessingMode:        common.Normal,
-		ProcessStatusHandler:  commonDisabled.NewProcessStatusHandler(),
-	})
-
-	return accountsAdapter, err
 }

--- a/trieTools/accountStorageExporter/vars.go
+++ b/trieTools/accountStorageExporter/vars.go
@@ -2,22 +2,9 @@ package main
 
 import (
 	logger "github.com/ElrondNetwork/elrond-go-logger"
-	elrondConfig "github.com/ElrondNetwork/elrond-go/config"
-	"github.com/ElrondNetwork/elrond-go/storage/storageUnit"
 )
 
 var (
-	cacheConfig = storageUnit.CacheConfig{
-		Type:        "SizeLRU",
-		Capacity:    500000,
-		SizeInBytes: 314572800, // 300MB
-	}
-	dbConfig = elrondConfig.DBConfig{
-		Type:              "LvlDBSerial",
-		BatchDelaySeconds: 2,
-		MaxBatchSize:      45000,
-		MaxOpenFiles:      10,
-	}
 	log             = logger.GetOrCreate("main")
 	outputFileName  = "output.json"
 	outputFilePerms = 0644

--- a/trieTools/go.mod
+++ b/trieTools/go.mod
@@ -6,13 +6,13 @@ require (
 	github.com/ElrondNetwork/elrond-go v1.3.35
 	github.com/ElrondNetwork/elrond-go-core v1.1.16-0.20220622092812-cc07c736c3b8
 	github.com/ElrondNetwork/elrond-go-logger v1.0.7
+	github.com/ElrondNetwork/elrond-vm-common v1.3.12
 	github.com/urfave/cli v1.22.9
 )
 
 require (
 	github.com/ElrondNetwork/concurrent-map v0.1.3 // indirect
 	github.com/ElrondNetwork/elrond-go-crypto v1.0.1 // indirect
-	github.com/ElrondNetwork/elrond-vm-common v1.3.12 // indirect
 	github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
 	github.com/denisbrodbeck/machineid v1.0.1 // indirect

--- a/trieTools/tokensExporter/config/config.go
+++ b/trieTools/tokensExporter/config/config.go
@@ -1,0 +1,9 @@
+package config
+
+import "github.com/ElrondNetwork/elrond-tools-go/trieTools/trieToolsCommon"
+
+// ContextFlagsTokensExporter is the flags config for tokens exporter
+type ContextFlagsTokensExporter struct {
+	trieToolsCommon.ContextFlagsConfig
+	Outfile string
+}

--- a/trieTools/tokensExporter/flags.go
+++ b/trieTools/tokensExporter/flags.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"github.com/ElrondNetwork/elrond-tools-go/trieTools/trieToolsCommon"
+	"github.com/urfave/cli"
+)
+
+func getFlags() []cli.Flag {
+	return []cli.Flag{
+		trieToolsCommon.WorkingDirectory,
+		trieToolsCommon.DbDirectory,
+		trieToolsCommon.LogLevel,
+		trieToolsCommon.DisableAnsiColor,
+		trieToolsCommon.LogSaveFile,
+		trieToolsCommon.LogWithLoggerName,
+		trieToolsCommon.ProfileMode,
+		trieToolsCommon.HexRootHash,
+	}
+}
+
+func getFlagsConfig(ctx *cli.Context) trieToolsCommon.ContextFlagsConfig {
+	flagsConfig := trieToolsCommon.ContextFlagsConfig{}
+
+	flagsConfig.WorkingDir = ctx.GlobalString(trieToolsCommon.WorkingDirectory.Name)
+	flagsConfig.DbDir = ctx.GlobalString(trieToolsCommon.DbDirectory.Name)
+	flagsConfig.LogLevel = ctx.GlobalString(trieToolsCommon.LogLevel.Name)
+	flagsConfig.SaveLogFile = ctx.GlobalBool(trieToolsCommon.LogSaveFile.Name)
+	flagsConfig.EnableLogName = ctx.GlobalBool(trieToolsCommon.LogWithLoggerName.Name)
+	flagsConfig.EnablePprof = ctx.GlobalBool(trieToolsCommon.ProfileMode.Name)
+	flagsConfig.HexRootHash = ctx.GlobalString(trieToolsCommon.HexRootHash.Name)
+
+	return flagsConfig
+}

--- a/trieTools/tokensExporter/flags.go
+++ b/trieTools/tokensExporter/flags.go
@@ -1,8 +1,17 @@
 package main
 
 import (
+	"github.com/ElrondNetwork/elrond-tools-go/trieTools/tokensExporter/config"
 	"github.com/ElrondNetwork/elrond-tools-go/trieTools/trieToolsCommon"
 	"github.com/urfave/cli"
+)
+
+var (
+	outfile = cli.StringFlag{
+		Name:  "outfile",
+		Usage: "This flag specifies where the output will be stored. It consists of a map<address, tokens>",
+		Value: "output.json",
+	}
 )
 
 func getFlags() []cli.Flag {
@@ -15,11 +24,12 @@ func getFlags() []cli.Flag {
 		trieToolsCommon.LogWithLoggerName,
 		trieToolsCommon.ProfileMode,
 		trieToolsCommon.HexRootHash,
+		outfile,
 	}
 }
 
-func getFlagsConfig(ctx *cli.Context) trieToolsCommon.ContextFlagsConfig {
-	flagsConfig := trieToolsCommon.ContextFlagsConfig{}
+func getFlagsConfig(ctx *cli.Context) config.ContextFlagsTokensExporter {
+	flagsConfig := config.ContextFlagsTokensExporter{}
 
 	flagsConfig.WorkingDir = ctx.GlobalString(trieToolsCommon.WorkingDirectory.Name)
 	flagsConfig.DbDir = ctx.GlobalString(trieToolsCommon.DbDirectory.Name)
@@ -28,6 +38,7 @@ func getFlagsConfig(ctx *cli.Context) trieToolsCommon.ContextFlagsConfig {
 	flagsConfig.EnableLogName = ctx.GlobalBool(trieToolsCommon.LogWithLoggerName.Name)
 	flagsConfig.EnablePprof = ctx.GlobalBool(trieToolsCommon.ProfileMode.Name)
 	flagsConfig.HexRootHash = ctx.GlobalString(trieToolsCommon.HexRootHash.Name)
+	flagsConfig.Outfile = ctx.GlobalString(outfile.Name)
 
 	return flagsConfig
 }

--- a/trieTools/tokensExporter/main.go
+++ b/trieTools/tokensExporter/main.go
@@ -1,8 +1,46 @@
 package main
 
 import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"github.com/ElrondNetwork/elrond-go-core/core"
+	"github.com/ElrondNetwork/elrond-go-core/core/check"
+	"github.com/ElrondNetwork/elrond-go-core/core/pubkeyConverter"
+	logger "github.com/ElrondNetwork/elrond-go-logger"
+	elrondFactory "github.com/ElrondNetwork/elrond-go/cmd/node/factory"
+	"github.com/ElrondNetwork/elrond-go/common"
+	commonDisabled "github.com/ElrondNetwork/elrond-go/common/disabled"
+	"github.com/ElrondNetwork/elrond-go/common/logging"
+	"github.com/ElrondNetwork/elrond-go/epochStart/notifier"
+	disabled2 "github.com/ElrondNetwork/elrond-go/state/storagePruningManager/disabled"
+
+	"github.com/ElrondNetwork/elrond-go/state"
+	stateFactory "github.com/ElrondNetwork/elrond-go/state/factory"
+	"github.com/ElrondNetwork/elrond-go/storage/databaseremover/disabled"
+	"github.com/ElrondNetwork/elrond-go/storage/factory"
+	"github.com/ElrondNetwork/elrond-go/storage/pruning"
+	"github.com/ElrondNetwork/elrond-go/testscommon"
+	"github.com/ElrondNetwork/elrond-go/trie"
+	"github.com/ElrondNetwork/elrond-tools-go/trieTools/trieToolsCommon"
+	"github.com/ElrondNetwork/elrond-tools-go/trieTools/trieToolsCommon/components"
 	"github.com/urfave/cli"
+	"io/ioutil"
+	"math/big"
 	"os"
+	"path"
+	"path/filepath"
+)
+
+const (
+	defaultLogsPath      = "logs"
+	logFilePrefix        = "trie-checker"
+	maxTrieLevelInMemory = 5
+	rootHashLength       = 32
+	addressLength        = 32
+	maxDirs              = 100
 )
 
 func main() {
@@ -32,5 +70,279 @@ func main() {
 }
 
 func startProcess(c *cli.Context) error {
+	flagsConfig := getFlagsConfig(c)
+
+	_, errLogger := attachFileLogger(log, flagsConfig)
+	if errLogger != nil {
+		return errLogger
+	}
+
+	log.Info("sanity checks...")
+
+	err := logger.SetLogLevel(flagsConfig.LogLevel)
+	if err != nil {
+		return err
+	}
+
+	rootHash, err := hex.DecodeString(flagsConfig.HexRootHash)
+	if err != nil {
+		return fmt.Errorf("%w when decoding the provided hex root hash", err)
+	}
+	if len(rootHash) != rootHashLength {
+		return fmt.Errorf("wrong root hash length: expected %d, got %d", rootHashLength, len(rootHash))
+	}
+
+	maxDBValue, err := getMaxDBValue(filepath.Join(flagsConfig.WorkingDir, flagsConfig.DbDir))
+	if err != nil {
+		return err
+	}
+
+	log.Info("starting processing trie", "pid", os.Getpid())
+
+	return exportTokens(flagsConfig, rootHash, maxDBValue)
+}
+
+func attachFileLogger(log logger.Logger, flagsConfig trieToolsCommon.ContextFlagsConfig) (elrondFactory.FileLoggingHandler, error) {
+	var fileLogging elrondFactory.FileLoggingHandler
+	var err error
+	if flagsConfig.SaveLogFile {
+		fileLogging, err = logging.NewFileLogging(logging.ArgsFileLogging{
+			WorkingDir:      flagsConfig.WorkingDir,
+			DefaultLogsPath: defaultLogsPath,
+			LogFilePrefix:   logFilePrefix,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("%w creating a log file", err)
+		}
+	}
+
+	err = logger.SetDisplayByteSlice(logger.ToHex)
+	log.LogIfError(err)
+	logger.ToggleLoggerName(flagsConfig.EnableLogName)
+	logLevelFlagValue := flagsConfig.LogLevel
+	err = logger.SetLogLevel(logLevelFlagValue)
+	if err != nil {
+		return nil, err
+	}
+
+	if flagsConfig.DisableAnsiColor {
+		err = logger.RemoveLogObserver(os.Stdout)
+		if err != nil {
+			return nil, err
+		}
+
+		err = logger.AddLogObserver(os.Stdout, &logger.PlainFormatter{})
+		if err != nil {
+			return nil, err
+		}
+	}
+	log.Trace("logger updated", "level", logLevelFlagValue, "disable ANSI color", flagsConfig.DisableAnsiColor)
+
+	return fileLogging, nil
+}
+
+func getMaxDBValue(parentDir string) (int, error) {
+	contents, err := ioutil.ReadDir(parentDir)
+	if err != nil {
+		return 0, err
+	}
+
+	directories := make([]string, 0)
+	for _, c := range contents {
+		if !c.IsDir() {
+			continue
+		}
+
+		_, ok := big.NewInt(0).SetString(c.Name(), 10)
+		if !ok {
+			log.Debug("DB directory found that will not be taken into account", "name", c.Name())
+			continue
+		}
+
+		directories = append(directories, c.Name())
+	}
+
+	numDirs := 0
+	for i := 0; i < maxDirs; i++ {
+		expectedDir := fmt.Sprintf("%d", i)
+		if !contains(directories, expectedDir) {
+			break
+		}
+
+		numDirs++
+	}
+
+	if numDirs == 0 {
+		return 0, fmt.Errorf("missing ordered directories in %s, like 0, 1 and so on", parentDir)
+	}
+	if numDirs != len(directories) {
+		return 0, fmt.Errorf("unordered directories in %s, like 0, 1 and so on", parentDir)
+	}
+
+	return numDirs - 1, nil
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, h := range haystack {
+		if h == needle {
+			return true
+		}
+	}
+
+	return false
+}
+
+func exportTokens(flags trieToolsCommon.ContextFlagsConfig, mainRootHash []byte, maxDBValue int) error {
+	addressConverter, err := pubkeyConverter.NewBech32PubkeyConverter(addressLength, log)
+	if err != nil {
+		return err
+	}
+
+	tr, err := getTrie(flags, maxDBValue)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		errNotCritical := tr.Close()
+		log.LogIfError(errNotCritical)
+	}()
+
+	ch := make(chan core.KeyValueHolder, common.TrieLeavesChannelDefaultCapacity)
+	err = tr.GetAllLeavesOnChannel(ch, context.Background(), mainRootHash)
+	if err != nil {
+		return err
+	}
+
+	accDb, err := newAccountsAdapter(tr)
+	if err != nil {
+		return err
+	}
+
+	err = accDb.RecreateTrie(mainRootHash)
+	if err != nil {
+		return err
+	}
+
+	numAccountsOnMainTrie := 0
+	ret := make(map[string]map[string]struct{})
+	for kv := range ch {
+		address := addressConverter.Encode(kv.Key())
+		addressBytes, err := addressConverter.Decode(address)
+		if err != nil {
+			return err
+		}
+
+		esdtTokens, err := GetAllESDTTokens(addressBytes, accDb)
+		log.LogIfError(err)
+
+		ret[address] = esdtTokens
+	}
+
+	log.Info("parsed main trie",
+		"num accounts", numAccountsOnMainTrie)
+
+	log.Info("parsed all tries",
+		"num accounts", numAccountsOnMainTrie)
+
 	return nil
+}
+
+func getTrie(flags trieToolsCommon.ContextFlagsConfig, maxDBValue int) (common.Trie, error) {
+	localDbConfig := dbConfig // copy
+	localDbConfig.FilePath = path.Join(flags.WorkingDir, flags.DbDir)
+
+	dbPath := path.Join(flags.WorkingDir, flags.DbDir)
+	args := &pruning.StorerArgs{
+		Identifier:                "",
+		ShardCoordinator:          testscommon.NewMultiShardsCoordinatorMock(1),
+		CacheConf:                 cacheConfig,
+		PathManager:               components.NewSimplePathManager(dbPath),
+		DbPath:                    "",
+		PersisterFactory:          factory.NewPersisterFactory(localDbConfig),
+		Notifier:                  notifier.NewManualEpochStartNotifier(),
+		OldDataCleanerProvider:    &testscommon.OldDataCleanerProviderStub{},
+		CustomDatabaseRemover:     disabled.NewDisabledCustomDatabaseRemover(),
+		MaxBatchSize:              45000,
+		NumOfEpochsToKeep:         uint32(maxDBValue) + 1,
+		NumOfActivePersisters:     uint32(maxDBValue) + 1,
+		StartingEpoch:             uint32(maxDBValue),
+		PruningEnabled:            true,
+		EnabledDbLookupExtensions: false,
+	}
+
+	db, err := pruning.NewTriePruningStorer(args)
+	if err != nil {
+		return nil, err
+	}
+
+	tsm, err := trie.NewTrieStorageManagerWithoutPruning(db)
+	if err != nil {
+		return nil, err
+	}
+
+	return trie.NewTrie(tsm, trieToolsCommon.Marshaller, trieToolsCommon.Hasher, maxTrieLevelInMemory)
+}
+
+func newAccountsAdapter(trie common.Trie) (state.AccountsAdapter, error) {
+	accCreator := stateFactory.NewAccountCreator()
+	storagePruningManager := disabled2.NewDisabledStoragePruningManager()
+	accountsAdapter, err := state.NewAccountsDB(state.ArgsAccountsDB{
+		Trie:                  trie,
+		Hasher:                trieToolsCommon.Hasher,
+		Marshaller:            trieToolsCommon.Marshaller,
+		AccountFactory:        accCreator,
+		StoragePruningManager: storagePruningManager,
+		ProcessingMode:        common.Normal,
+		ProcessStatusHandler:  commonDisabled.NewProcessStatusHandler(),
+	})
+
+	return accountsAdapter, err
+}
+
+// ----------------------------
+// GetAllESDTTokens returns all the ESDTs that the given address interacted with
+func GetAllESDTTokens(address []byte, accDb state.AccountsAdapter) (map[string]struct{}, error) {
+
+	account, err := accDb.GetExistingAccount(address)
+	if err != nil {
+		return nil, err
+	}
+
+	userAccount, ok := account.(state.UserAccountHandler)
+	if !ok {
+		return nil, errors.New("could not convert to user account")
+	}
+
+	allESDTs := make(map[string]struct{})
+	if check.IfNil(userAccount.DataTrie()) {
+		return allESDTs, nil
+	}
+
+	esdtPrefix := []byte(core.ElrondProtectedKeyPrefix + core.ESDTKeyIdentifier)
+	lenESDTPrefix := len(esdtPrefix)
+
+	rootHash, err := userAccount.DataTrie().RootHash()
+	if err != nil {
+		return nil, err
+	}
+
+	chLeaves := make(chan core.KeyValueHolder, common.TrieLeavesChannelDefaultCapacity)
+	err = userAccount.DataTrie().GetAllLeavesOnChannel(chLeaves, context.Background(), rootHash)
+	if err != nil {
+		return nil, err
+	}
+
+	for leaf := range chLeaves {
+		if !bytes.HasPrefix(leaf.Key(), esdtPrefix) {
+			continue
+		}
+
+		tokenKey := leaf.Key()
+		tokenName := string(tokenKey[lenESDTPrefix:])
+
+		allESDTs[tokenName] = struct{}{}
+	}
+
+	return allESDTs, nil
 }

--- a/trieTools/tokensExporter/main.go
+++ b/trieTools/tokensExporter/main.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"github.com/urfave/cli"
 	"io/fs"
 	"io/ioutil"
 	"os"
@@ -21,6 +20,7 @@ import (
 	"github.com/ElrondNetwork/elrond-tools-go/trieTools/tokensExporter/config"
 	"github.com/ElrondNetwork/elrond-tools-go/trieTools/trieToolsCommon"
 	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
+	"github.com/urfave/cli"
 )
 
 const (

--- a/trieTools/tokensExporter/main.go
+++ b/trieTools/tokensExporter/main.go
@@ -10,40 +10,23 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	"github.com/ElrondNetwork/elrond-go-core/core/pubkeyConverter"
 	logger "github.com/ElrondNetwork/elrond-go-logger"
-	elrondFactory "github.com/ElrondNetwork/elrond-go/cmd/node/factory"
 	"github.com/ElrondNetwork/elrond-go/common"
-	commonDisabled "github.com/ElrondNetwork/elrond-go/common/disabled"
-	"github.com/ElrondNetwork/elrond-go/common/logging"
-	"github.com/ElrondNetwork/elrond-go/epochStart/notifier"
 	"github.com/ElrondNetwork/elrond-go/state"
-	stateFactory "github.com/ElrondNetwork/elrond-go/state/factory"
-	disabled2 "github.com/ElrondNetwork/elrond-go/state/storagePruningManager/disabled"
-	"github.com/ElrondNetwork/elrond-go/storage/databaseremover/disabled"
-	"github.com/ElrondNetwork/elrond-go/storage/factory"
-	"github.com/ElrondNetwork/elrond-go/storage/pruning"
-	"github.com/ElrondNetwork/elrond-go/testscommon"
-	"github.com/ElrondNetwork/elrond-go/trie"
 	"github.com/ElrondNetwork/elrond-tools-go/trieTools/tokensExporter/config"
 	"github.com/ElrondNetwork/elrond-tools-go/trieTools/trieToolsCommon"
-	"github.com/ElrondNetwork/elrond-tools-go/trieTools/trieToolsCommon/components"
 	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
 	"github.com/urfave/cli"
 	"io/fs"
 	"io/ioutil"
-	"math/big"
 	"os"
-	"path"
 	"path/filepath"
 )
 
 const (
-	defaultLogsPath      = "logs"
-	logFilePrefix        = "accounts-tokens-exporter"
-	maxTrieLevelInMemory = 5
-	rootHashLength       = 32
-	addressLength        = 32
-	maxDirs              = 100
-	outputFilePerms      = 0644
+	logFilePrefix   = "accounts-tokens-exporter"
+	rootHashLength  = 32
+	addressLength   = 32
+	outputFilePerms = 0644
 )
 
 func main() {
@@ -73,7 +56,7 @@ func main() {
 func startProcess(c *cli.Context) error {
 	flagsConfig := getFlagsConfig(c)
 
-	_, errLogger := attachFileLogger(log, flagsConfig.ContextFlagsConfig)
+	_, errLogger := trieToolsCommon.AttachFileLogger(log, logFilePrefix, flagsConfig.ContextFlagsConfig)
 	if errLogger != nil {
 		return errLogger
 	}
@@ -93,7 +76,7 @@ func startProcess(c *cli.Context) error {
 		return fmt.Errorf("wrong root hash length: expected %d, got %d", rootHashLength, len(rootHash))
 	}
 
-	maxDBValue, err := getMaxDBValue(filepath.Join(flagsConfig.WorkingDir, flagsConfig.DbDir))
+	maxDBValue, err := trieToolsCommon.GetMaxDBValue(filepath.Join(flagsConfig.WorkingDir, flagsConfig.DbDir), log)
 	if err != nil {
 		return err
 	}
@@ -103,103 +86,13 @@ func startProcess(c *cli.Context) error {
 	return exportTokens(flagsConfig, rootHash, maxDBValue)
 }
 
-func attachFileLogger(log logger.Logger, flagsConfig trieToolsCommon.ContextFlagsConfig) (elrondFactory.FileLoggingHandler, error) {
-	var fileLogging elrondFactory.FileLoggingHandler
-	var err error
-	if flagsConfig.SaveLogFile {
-		fileLogging, err = logging.NewFileLogging(logging.ArgsFileLogging{
-			WorkingDir:      flagsConfig.WorkingDir,
-			DefaultLogsPath: defaultLogsPath,
-			LogFilePrefix:   logFilePrefix,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("%w creating a log file", err)
-		}
-	}
-
-	err = logger.SetDisplayByteSlice(logger.ToHex)
-	log.LogIfError(err)
-	logger.ToggleLoggerName(flagsConfig.EnableLogName)
-	logLevelFlagValue := flagsConfig.LogLevel
-	err = logger.SetLogLevel(logLevelFlagValue)
-	if err != nil {
-		return nil, err
-	}
-
-	if flagsConfig.DisableAnsiColor {
-		err = logger.RemoveLogObserver(os.Stdout)
-		if err != nil {
-			return nil, err
-		}
-
-		err = logger.AddLogObserver(os.Stdout, &logger.PlainFormatter{})
-		if err != nil {
-			return nil, err
-		}
-	}
-	log.Trace("logger updated", "level", logLevelFlagValue, "disable ANSI color", flagsConfig.DisableAnsiColor)
-
-	return fileLogging, nil
-}
-
-func getMaxDBValue(parentDir string) (int, error) {
-	contents, err := ioutil.ReadDir(parentDir)
-	if err != nil {
-		return 0, err
-	}
-
-	directories := make([]string, 0)
-	for _, c := range contents {
-		if !c.IsDir() {
-			continue
-		}
-
-		_, ok := big.NewInt(0).SetString(c.Name(), 10)
-		if !ok {
-			log.Debug("DB directory found that will not be taken into account", "name", c.Name())
-			continue
-		}
-
-		directories = append(directories, c.Name())
-	}
-
-	numDirs := 0
-	for i := 0; i < maxDirs; i++ {
-		expectedDir := fmt.Sprintf("%d", i)
-		if !contains(directories, expectedDir) {
-			break
-		}
-
-		numDirs++
-	}
-
-	if numDirs == 0 {
-		return 0, fmt.Errorf("missing ordered directories in %s, like 0, 1 and so on", parentDir)
-	}
-	if numDirs != len(directories) {
-		return 0, fmt.Errorf("unordered directories in %s, like 0, 1 and so on", parentDir)
-	}
-
-	return numDirs - 1, nil
-}
-
-func contains(haystack []string, needle string) bool {
-	for _, h := range haystack {
-		if h == needle {
-			return true
-		}
-	}
-
-	return false
-}
-
 func exportTokens(flags config.ContextFlagsTokensExporter, mainRootHash []byte, maxDBValue int) error {
 	addressConverter, err := pubkeyConverter.NewBech32PubkeyConverter(addressLength, log)
 	if err != nil {
 		return err
 	}
 
-	tr, err := getTrie(flags.ContextFlagsConfig, maxDBValue)
+	tr, err := trieToolsCommon.GetTrie(flags.ContextFlagsConfig, maxDBValue)
 	if err != nil {
 		return err
 	}
@@ -215,7 +108,7 @@ func exportTokens(flags config.ContextFlagsTokensExporter, mainRootHash []byte, 
 		return err
 	}
 
-	accDb, err := newAccountsAdapter(tr)
+	accDb, err := trieToolsCommon.NewAccountsAdapter(tr)
 	if err != nil {
 		return err
 	}
@@ -293,58 +186,6 @@ func saveResult(addressTokensMap map[string]map[string]struct{}, outfile string)
 
 	log.Info("finished exporting address-tokens map")
 	return nil
-}
-
-func getTrie(flags trieToolsCommon.ContextFlagsConfig, maxDBValue int) (common.Trie, error) {
-	localDbConfig := dbConfig // copy
-	localDbConfig.FilePath = path.Join(flags.WorkingDir, flags.DbDir)
-
-	dbPath := path.Join(flags.WorkingDir, flags.DbDir)
-	args := &pruning.StorerArgs{
-		Identifier:                "",
-		ShardCoordinator:          testscommon.NewMultiShardsCoordinatorMock(1),
-		CacheConf:                 cacheConfig,
-		PathManager:               components.NewSimplePathManager(dbPath),
-		DbPath:                    "",
-		PersisterFactory:          factory.NewPersisterFactory(localDbConfig),
-		Notifier:                  notifier.NewManualEpochStartNotifier(),
-		OldDataCleanerProvider:    &testscommon.OldDataCleanerProviderStub{},
-		CustomDatabaseRemover:     disabled.NewDisabledCustomDatabaseRemover(),
-		MaxBatchSize:              45000,
-		NumOfEpochsToKeep:         uint32(maxDBValue) + 1,
-		NumOfActivePersisters:     uint32(maxDBValue) + 1,
-		StartingEpoch:             uint32(maxDBValue),
-		PruningEnabled:            true,
-		EnabledDbLookupExtensions: false,
-	}
-
-	db, err := pruning.NewTriePruningStorer(args)
-	if err != nil {
-		return nil, err
-	}
-
-	tsm, err := trie.NewTrieStorageManagerWithoutPruning(db)
-	if err != nil {
-		return nil, err
-	}
-
-	return trie.NewTrie(tsm, trieToolsCommon.Marshaller, trieToolsCommon.Hasher, maxTrieLevelInMemory)
-}
-
-func newAccountsAdapter(trie common.Trie) (state.AccountsAdapter, error) {
-	accCreator := stateFactory.NewAccountCreator()
-	storagePruningManager := disabled2.NewDisabledStoragePruningManager()
-	accountsAdapter, err := state.NewAccountsDB(state.ArgsAccountsDB{
-		Trie:                  trie,
-		Hasher:                trieToolsCommon.Hasher,
-		Marshaller:            trieToolsCommon.Marshaller,
-		AccountFactory:        accCreator,
-		StoragePruningManager: storagePruningManager,
-		ProcessingMode:        common.Normal,
-		ProcessStatusHandler:  commonDisabled.NewProcessStatusHandler(),
-	})
-
-	return accountsAdapter, err
 }
 
 func getAllESDTTokens(account vmcommon.AccountHandler) (map[string]struct{}, error) {

--- a/trieTools/tokensExporter/main.go
+++ b/trieTools/tokensExporter/main.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"github.com/urfave/cli"
+	"os"
+)
+
+func main() {
+	app := cli.NewApp()
+	app.Name = "Tokens exporter CLI app"
+	app.Usage = "This is the entry point for the tool that exports all address balances for a given root hash"
+	app.Flags = getFlags()
+	app.Authors = []cli.Author{
+		{
+			Name:  "The Elrond Team",
+			Email: "contact@elrond.com",
+		},
+	}
+
+	app.Action = func(c *cli.Context) error {
+		return startProcess(c)
+	}
+
+	err := app.Run(os.Args)
+	if err != nil {
+		log.Error(err.Error())
+		os.Exit(1)
+		return
+	}
+
+	log.Info("finished exporting token's balances")
+}
+
+func startProcess(c *cli.Context) error {
+	return nil
+}

--- a/trieTools/tokensExporter/main.go
+++ b/trieTools/tokensExporter/main.go
@@ -144,15 +144,15 @@ func exportTokens(flags config.ContextFlagsTokensExporter, mainRootHash []byte, 
 		}
 	}
 
-	encodedAddress := addressConverter.Encode(vmcommon.SystemAccountAddress)
+	encodedSysAccAddress := addressConverter.Encode(vmcommon.SystemAccountAddress)
 	log.Info("parsed main trie",
 		"num accounts", numAccountsOnMainTrie,
 		"num accounts with tokens", len(addressTokensMap),
-		"num tokens in system account address", len(addressTokensMap[encodedAddress]))
+		"num tokens in system account address", len(addressTokensMap[encodedSysAccAddress]))
 
-	_, found := addressTokensMap[encodedAddress]
+	_, found := addressTokensMap[encodedSysAccAddress]
 	if !found {
-		log.Warn(fmt.Sprintf("system account address(%s) not found, input dbs might be incomplete/corrupted", encodedAddress))
+		log.Warn(fmt.Sprintf("system account address(%s) not found, input dbs might be incomplete/corrupted", encodedSysAccAddress))
 	}
 
 	return saveResult(addressTokensMap, flags.Outfile)

--- a/trieTools/tokensExporter/vars.go
+++ b/trieTools/tokensExporter/vars.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	logger "github.com/ElrondNetwork/elrond-go-logger"
+	elrondConfig "github.com/ElrondNetwork/elrond-go/config"
+	"github.com/ElrondNetwork/elrond-go/storage/storageUnit"
+)
+
+var (
+	cacheConfig = storageUnit.CacheConfig{
+		Type:        "SizeLRU",
+		Capacity:    500000,
+		SizeInBytes: 314572800, // 300MB
+	}
+	dbConfig = elrondConfig.DBConfig{
+		Type:              "LvlDBSerial",
+		BatchDelaySeconds: 2,
+		MaxBatchSize:      45000,
+		MaxOpenFiles:      10,
+	}
+	log = logger.GetOrCreate("main")
+)

--- a/trieTools/tokensExporter/vars.go
+++ b/trieTools/tokensExporter/vars.go
@@ -2,21 +2,8 @@ package main
 
 import (
 	logger "github.com/ElrondNetwork/elrond-go-logger"
-	elrondConfig "github.com/ElrondNetwork/elrond-go/config"
-	"github.com/ElrondNetwork/elrond-go/storage/storageUnit"
 )
 
 var (
-	cacheConfig = storageUnit.CacheConfig{
-		Type:        "SizeLRU",
-		Capacity:    500000,
-		SizeInBytes: 314572800, // 300MB
-	}
-	dbConfig = elrondConfig.DBConfig{
-		Type:              "LvlDBSerial",
-		BatchDelaySeconds: 2,
-		MaxBatchSize:      45000,
-		MaxOpenFiles:      10,
-	}
 	log = logger.GetOrCreate("main")
 )

--- a/trieTools/trieChecker/main.go
+++ b/trieTools/trieChecker/main.go
@@ -4,37 +4,22 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
-	"math/big"
 	"os"
-	"path"
 	"path/filepath"
 
 	"github.com/ElrondNetwork/elrond-go-core/core"
 	"github.com/ElrondNetwork/elrond-go-core/core/pubkeyConverter"
 	logger "github.com/ElrondNetwork/elrond-go-logger"
-	elrondFactory "github.com/ElrondNetwork/elrond-go/cmd/node/factory"
 	"github.com/ElrondNetwork/elrond-go/common"
-	"github.com/ElrondNetwork/elrond-go/common/logging"
-	"github.com/ElrondNetwork/elrond-go/epochStart/notifier"
 	"github.com/ElrondNetwork/elrond-go/state"
-	"github.com/ElrondNetwork/elrond-go/storage/databaseremover/disabled"
-	"github.com/ElrondNetwork/elrond-go/storage/factory"
-	"github.com/ElrondNetwork/elrond-go/storage/pruning"
-	"github.com/ElrondNetwork/elrond-go/testscommon"
-	"github.com/ElrondNetwork/elrond-go/trie"
 	"github.com/ElrondNetwork/elrond-tools-go/trieTools/trieToolsCommon"
-	"github.com/ElrondNetwork/elrond-tools-go/trieTools/trieToolsCommon/components"
 	"github.com/urfave/cli"
 )
 
 const (
-	defaultLogsPath      = "logs"
-	logFilePrefix        = "trie-checker"
-	maxTrieLevelInMemory = 5
-	rootHashLength       = 32
-	addressLength        = 32
-	maxDirs              = 100
+	logFilePrefix  = "trie-checker"
+	rootHashLength = 32
+	addressLength  = 32
 )
 
 func main() {
@@ -66,7 +51,7 @@ func main() {
 func startProcess(c *cli.Context) error {
 	flagsConfig := getFlagsConfig(c)
 
-	_, errLogger := attachFileLogger(log, flagsConfig)
+	_, errLogger := trieToolsCommon.AttachFileLogger(log, logFilePrefix, flagsConfig)
 	if errLogger != nil {
 		return errLogger
 	}
@@ -86,7 +71,7 @@ func startProcess(c *cli.Context) error {
 		return fmt.Errorf("wrong root hash length: expected %d, got %d", rootHashLength, len(rootHash))
 	}
 
-	maxDBValue, err := getMaxDBValue(filepath.Join(flagsConfig.WorkingDir, flagsConfig.DbDir))
+	maxDBValue, err := trieToolsCommon.GetMaxDBValue(filepath.Join(flagsConfig.WorkingDir, flagsConfig.DbDir), log)
 	if err != nil {
 		return err
 	}
@@ -96,103 +81,13 @@ func startProcess(c *cli.Context) error {
 	return checkTrie(flagsConfig, rootHash, maxDBValue)
 }
 
-func attachFileLogger(log logger.Logger, flagsConfig trieToolsCommon.ContextFlagsConfig) (elrondFactory.FileLoggingHandler, error) {
-	var fileLogging elrondFactory.FileLoggingHandler
-	var err error
-	if flagsConfig.SaveLogFile {
-		fileLogging, err = logging.NewFileLogging(logging.ArgsFileLogging{
-			WorkingDir:      flagsConfig.WorkingDir,
-			DefaultLogsPath: defaultLogsPath,
-			LogFilePrefix:   logFilePrefix,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("%w creating a log file", err)
-		}
-	}
-
-	err = logger.SetDisplayByteSlice(logger.ToHex)
-	log.LogIfError(err)
-	logger.ToggleLoggerName(flagsConfig.EnableLogName)
-	logLevelFlagValue := flagsConfig.LogLevel
-	err = logger.SetLogLevel(logLevelFlagValue)
-	if err != nil {
-		return nil, err
-	}
-
-	if flagsConfig.DisableAnsiColor {
-		err = logger.RemoveLogObserver(os.Stdout)
-		if err != nil {
-			return nil, err
-		}
-
-		err = logger.AddLogObserver(os.Stdout, &logger.PlainFormatter{})
-		if err != nil {
-			return nil, err
-		}
-	}
-	log.Trace("logger updated", "level", logLevelFlagValue, "disable ANSI color", flagsConfig.DisableAnsiColor)
-
-	return fileLogging, nil
-}
-
-func getMaxDBValue(parentDir string) (int, error) {
-	contents, err := ioutil.ReadDir(parentDir)
-	if err != nil {
-		return 0, err
-	}
-
-	directories := make([]string, 0)
-	for _, c := range contents {
-		if !c.IsDir() {
-			continue
-		}
-
-		_, ok := big.NewInt(0).SetString(c.Name(), 10)
-		if !ok {
-			log.Debug("DB directory found that will not be taken into account", "name", c.Name())
-			continue
-		}
-
-		directories = append(directories, c.Name())
-	}
-
-	numDirs := 0
-	for i := 0; i < maxDirs; i++ {
-		expectedDir := fmt.Sprintf("%d", i)
-		if !contains(directories, expectedDir) {
-			break
-		}
-
-		numDirs++
-	}
-
-	if numDirs == 0 {
-		return 0, fmt.Errorf("missing ordered directories in %s, like 0, 1 and so on", parentDir)
-	}
-	if numDirs != len(directories) {
-		return 0, fmt.Errorf("unordered directories in %s, like 0, 1 and so on", parentDir)
-	}
-
-	return numDirs - 1, nil
-}
-
-func contains(haystack []string, needle string) bool {
-	for _, h := range haystack {
-		if h == needle {
-			return true
-		}
-	}
-
-	return false
-}
-
 func checkTrie(flags trieToolsCommon.ContextFlagsConfig, mainRootHash []byte, maxDBValue int) error {
 	addressConverter, err := pubkeyConverter.NewBech32PubkeyConverter(addressLength, log)
 	if err != nil {
 		return err
 	}
 
-	tr, err := getTrie(flags, maxDBValue)
+	tr, err := trieToolsCommon.GetTrie(flags, maxDBValue)
 	if err != nil {
 		return err
 	}
@@ -262,40 +157,4 @@ func checkTrie(flags trieToolsCommon.ContextFlagsConfig, mainRootHash []byte, ma
 		"num data tries leaves", numDataTriesLeaves)
 
 	return nil
-}
-
-func getTrie(flags trieToolsCommon.ContextFlagsConfig, maxDBValue int) (common.Trie, error) {
-	localDbConfig := dbConfig // copy
-	localDbConfig.FilePath = path.Join(flags.WorkingDir, flags.DbDir)
-
-	dbPath := path.Join(flags.WorkingDir, flags.DbDir)
-	args := &pruning.StorerArgs{
-		Identifier:                "",
-		ShardCoordinator:          testscommon.NewMultiShardsCoordinatorMock(1),
-		CacheConf:                 cacheConfig,
-		PathManager:               components.NewSimplePathManager(dbPath),
-		DbPath:                    "",
-		PersisterFactory:          factory.NewPersisterFactory(localDbConfig),
-		Notifier:                  notifier.NewManualEpochStartNotifier(),
-		OldDataCleanerProvider:    &testscommon.OldDataCleanerProviderStub{},
-		CustomDatabaseRemover:     disabled.NewDisabledCustomDatabaseRemover(),
-		MaxBatchSize:              45000,
-		NumOfEpochsToKeep:         uint32(maxDBValue) + 1,
-		NumOfActivePersisters:     uint32(maxDBValue) + 1,
-		StartingEpoch:             uint32(maxDBValue),
-		PruningEnabled:            true,
-		EnabledDbLookupExtensions: false,
-	}
-
-	db, err := pruning.NewTriePruningStorer(args)
-	if err != nil {
-		return nil, err
-	}
-
-	tsm, err := trie.NewTrieStorageManagerWithoutPruning(db)
-	if err != nil {
-		return nil, err
-	}
-
-	return trie.NewTrie(tsm, trieToolsCommon.Marshaller, trieToolsCommon.Hasher, maxTrieLevelInMemory)
 }

--- a/trieTools/trieChecker/vars.go
+++ b/trieTools/trieChecker/vars.go
@@ -2,21 +2,8 @@ package main
 
 import (
 	logger "github.com/ElrondNetwork/elrond-go-logger"
-	elrondConfig "github.com/ElrondNetwork/elrond-go/config"
-	"github.com/ElrondNetwork/elrond-go/storage/storageUnit"
 )
 
 var (
-	cacheConfig = storageUnit.CacheConfig{
-		Type:        "SizeLRU",
-		Capacity:    500000,
-		SizeInBytes: 314572800, // 300MB
-	}
-	dbConfig = elrondConfig.DBConfig{
-		Type:              "LvlDBSerial",
-		BatchDelaySeconds: 2,
-		MaxBatchSize:      45000,
-		MaxOpenFiles:      10,
-	}
 	log = logger.GetOrCreate("main")
 )

--- a/trieTools/trieToolsCommon/common.go
+++ b/trieTools/trieToolsCommon/common.go
@@ -1,0 +1,176 @@
+package trieToolsCommon
+
+import (
+	"fmt"
+	logger "github.com/ElrondNetwork/elrond-go-logger"
+	elrondFactory "github.com/ElrondNetwork/elrond-go/cmd/node/factory"
+	"github.com/ElrondNetwork/elrond-go/common"
+	commonDisabled "github.com/ElrondNetwork/elrond-go/common/disabled"
+	"github.com/ElrondNetwork/elrond-go/common/logging"
+	"github.com/ElrondNetwork/elrond-go/epochStart/notifier"
+	"github.com/ElrondNetwork/elrond-go/state"
+	stateFactory "github.com/ElrondNetwork/elrond-go/state/factory"
+	disabled2 "github.com/ElrondNetwork/elrond-go/state/storagePruningManager/disabled"
+	"github.com/ElrondNetwork/elrond-go/storage/databaseremover/disabled"
+	"github.com/ElrondNetwork/elrond-go/storage/factory"
+	"github.com/ElrondNetwork/elrond-go/storage/pruning"
+	"github.com/ElrondNetwork/elrond-go/testscommon"
+	"github.com/ElrondNetwork/elrond-go/trie"
+	"github.com/ElrondNetwork/elrond-tools-go/trieTools/trieToolsCommon/components"
+	"io/ioutil"
+	"math/big"
+	"os"
+	"path"
+)
+
+const (
+	defaultLogsPath      = "logs"
+	maxTrieLevelInMemory = 5
+	maxDirs              = 100
+)
+
+// AttachFileLogger will attach the file logger, using provided flags
+func AttachFileLogger(log logger.Logger, logFilePrefix string, flagsConfig ContextFlagsConfig) (elrondFactory.FileLoggingHandler, error) {
+	var fileLogging elrondFactory.FileLoggingHandler
+	var err error
+	if flagsConfig.SaveLogFile {
+		fileLogging, err = logging.NewFileLogging(logging.ArgsFileLogging{
+			WorkingDir:      flagsConfig.WorkingDir,
+			DefaultLogsPath: defaultLogsPath,
+			LogFilePrefix:   logFilePrefix,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("%w creating a log file", err)
+		}
+	}
+
+	err = logger.SetDisplayByteSlice(logger.ToHex)
+	log.LogIfError(err)
+	logger.ToggleLoggerName(flagsConfig.EnableLogName)
+	logLevelFlagValue := flagsConfig.LogLevel
+	err = logger.SetLogLevel(logLevelFlagValue)
+	if err != nil {
+		return nil, err
+	}
+
+	if flagsConfig.DisableAnsiColor {
+		err = logger.RemoveLogObserver(os.Stdout)
+		if err != nil {
+			return nil, err
+		}
+
+		err = logger.AddLogObserver(os.Stdout, &logger.PlainFormatter{})
+		if err != nil {
+			return nil, err
+		}
+	}
+	log.Trace("logger updated", "level", logLevelFlagValue, "disable ANSI color", flagsConfig.DisableAnsiColor)
+
+	return fileLogging, nil
+}
+
+// GetMaxDBValue will search in parentDir for all dbs directories and return max db value
+func GetMaxDBValue(parentDir string, log logger.Logger) (int, error) {
+	contents, err := ioutil.ReadDir(parentDir)
+	if err != nil {
+		return 0, err
+	}
+
+	directories := make([]string, 0)
+	for _, c := range contents {
+		if !c.IsDir() {
+			continue
+		}
+
+		_, ok := big.NewInt(0).SetString(c.Name(), 10)
+		if !ok {
+			log.Debug("DB directory found that will not be taken into account", "name", c.Name())
+			continue
+		}
+
+		directories = append(directories, c.Name())
+	}
+
+	numDirs := 0
+	for i := 0; i < maxDirs; i++ {
+		expectedDir := fmt.Sprintf("%d", i)
+		if !contains(directories, expectedDir) {
+			break
+		}
+
+		numDirs++
+	}
+
+	if numDirs == 0 {
+		return 0, fmt.Errorf("missing ordered directories in %s, like 0, 1 and so on", parentDir)
+	}
+	if numDirs != len(directories) {
+		return 0, fmt.Errorf("unordered directories in %s, like 0, 1 and so on", parentDir)
+	}
+
+	return numDirs - 1, nil
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, h := range haystack {
+		if h == needle {
+			return true
+		}
+	}
+
+	return false
+}
+
+// GetTrie will create and return a trie using the provided flags
+func GetTrie(flags ContextFlagsConfig, maxDBValue int) (common.Trie, error) {
+	localDbConfig := dbConfig // copy
+	localDbConfig.FilePath = path.Join(flags.WorkingDir, flags.DbDir)
+
+	dbPath := path.Join(flags.WorkingDir, flags.DbDir)
+	args := &pruning.StorerArgs{
+		Identifier:                "",
+		ShardCoordinator:          testscommon.NewMultiShardsCoordinatorMock(1),
+		CacheConf:                 cacheConfig,
+		PathManager:               components.NewSimplePathManager(dbPath),
+		DbPath:                    "",
+		PersisterFactory:          factory.NewPersisterFactory(localDbConfig),
+		Notifier:                  notifier.NewManualEpochStartNotifier(),
+		OldDataCleanerProvider:    &testscommon.OldDataCleanerProviderStub{},
+		CustomDatabaseRemover:     disabled.NewDisabledCustomDatabaseRemover(),
+		MaxBatchSize:              45000,
+		NumOfEpochsToKeep:         uint32(maxDBValue) + 1,
+		NumOfActivePersisters:     uint32(maxDBValue) + 1,
+		StartingEpoch:             uint32(maxDBValue),
+		PruningEnabled:            true,
+		EnabledDbLookupExtensions: false,
+	}
+
+	db, err := pruning.NewTriePruningStorer(args)
+	if err != nil {
+		return nil, err
+	}
+
+	tsm, err := trie.NewTrieStorageManagerWithoutPruning(db)
+	if err != nil {
+		return nil, err
+	}
+
+	return trie.NewTrie(tsm, Marshaller, Hasher, maxTrieLevelInMemory)
+}
+
+// NewAccountsAdapter will create a new accounts adapter using provided trie
+func NewAccountsAdapter(trie common.Trie) (state.AccountsAdapter, error) {
+	accCreator := stateFactory.NewAccountCreator()
+	storagePruningManager := disabled2.NewDisabledStoragePruningManager()
+	accountsAdapter, err := state.NewAccountsDB(state.ArgsAccountsDB{
+		Trie:                  trie,
+		Hasher:                Hasher,
+		Marshaller:            Marshaller,
+		AccountFactory:        accCreator,
+		StoragePruningManager: storagePruningManager,
+		ProcessingMode:        common.Normal,
+		ProcessStatusHandler:  commonDisabled.NewProcessStatusHandler(),
+	})
+
+	return accountsAdapter, err
+}

--- a/trieTools/trieToolsCommon/vars.go
+++ b/trieTools/trieToolsCommon/vars.go
@@ -3,6 +3,8 @@ package trieToolsCommon
 import (
 	"github.com/ElrondNetwork/elrond-go-core/hashing/blake2b"
 	"github.com/ElrondNetwork/elrond-go-core/marshal"
+	elrondConfig "github.com/ElrondNetwork/elrond-go/config"
+	"github.com/ElrondNetwork/elrond-go/storage/storageUnit"
 )
 
 var (
@@ -10,4 +12,16 @@ var (
 	Hasher = blake2b.NewBlake2b()
 	// Marshaller represents the internal marshaller used by the node
 	Marshaller = &marshal.GogoProtoMarshalizer{}
+
+	cacheConfig = storageUnit.CacheConfig{
+		Type:        "SizeLRU",
+		Capacity:    500000,
+		SizeInBytes: 314572800, // 300MB
+	}
+	dbConfig = elrondConfig.DBConfig{
+		Type:              "LvlDBSerial",
+		BatchDelaySeconds: 2,
+		MaxBatchSize:      45000,
+		MaxOpenFiles:      10,
+	}
 )


### PR DESCRIPTION
Description
--

- Created tool that exports all tokens for all addresses from given dbs. The output will be exported as map<address, map<tokens> >
- Moved duplicated functions in `common.go`, along with their constants: `AttachFileLogger`, `GetMaxDBValue`, `GetTrie`, `NewAccountsAdapter`. The code inside functions shall not be reviewed. One reviewer should only check that the contents are identical and no logic has been changed in affected refactored files.

How to use it
--

- This tool exports <address, tokens> per shard. Therefore, for each shard, you need:
1. AccountsTrieDBs for 2 epochs(stored in `db` folder-> epoch X dbs stored in: `0` directory, epoch X-1 dbs stored in `1` directory)
2. Hex root hash = the root hash at which the snapshot was taken at the end of the epoch (epoch X+1).

Example
--
**Example for shard 0:**
- Root hash for epoch = 727 (X+1) = `d6667e00eb62a10f49efbd9879dacba14e652bdd0e92be92bca84cda850b72bc`
- `db` folder at the same directory level as the built binary
|
|--`db`--| ->`0` -> store here `AccountsTrieDB` from epoch = 725 (X-1)
|_____ |-->`1` -> store here  `AccountsTrieDB` from epoch = 726 (X)
|

-> **Run**:
`
./tokensExporter --db-directory db --hex-roothash d6667e00eb62a10f49efbd9879dacba14e652bdd0e92be92bca84cda850b72bc --outfile test.json
`

-> **You should have 0 warnings/errors.** At the end, logs should print a message like:
`
INFO [2022-08-04 14:15:33.446]   parsed main trie  num accounts = 326814 num accounts with tokens = 100105 num tokens in system account address = 911571 
`
`
INFO [2022-08-04 14:15:34.961]   writing result in                        file = test.json 
`
`
INFO [2022-08-04 14:15:34.991]   finished exporting address-tokens map  
`

-> **Output in `test.json` should look like**:
```{
 "erd1000ptk5s9cucdy7w9482a34t49x4lqc53hewax74tllvlmgvpxuqpqmee0": {
  "SRIDE-4ab1d4-01aab2": {}
 },
 "erd1000qzks5fdxhyhzxxr79mhl2vyc2ahssxjnly5udvn0pfdn7sgyqdcxkee": {
  "AERO-458bbf": {},
  "BHAT-c1fde3": {},
  "CRT-52decf": {},
  "CRTMBT-9b5699-02": {},
  "EFFORT-a13513": {},
.