### PR TITLE
Zero token balance system account exporter

### DIFF
--- a/trieTools/zeroBalanceSystemAccountChecker/flags.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/flags.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"github.com/ElrondNetwork/elrond-tools-go/trieTools/trieToolsCommon"
+	"github.com/urfave/cli"
+)
+
+var (
+	tokensDirectory = cli.StringFlag{
+		Name:  "tokens-dir",
+		Usage: "This flag specifies the `directory` where the application will find all exported tokens from all shards",
+		Value: "in",
+	}
+)
+
+type ContextFlagsZeroBalanceSysAcc struct {
+	trieToolsCommon.ContextFlagsConfig
+	tokensDirectory string
+}
+
+func getFlags() []cli.Flag {
+	return []cli.Flag{
+		trieToolsCommon.WorkingDirectory,
+		trieToolsCommon.LogLevel,
+		trieToolsCommon.DisableAnsiColor,
+		trieToolsCommon.LogSaveFile,
+		trieToolsCommon.LogWithLoggerName,
+		trieToolsCommon.ProfileMode,
+		tokensDirectory,
+	}
+}
+
+func getFlagsConfig(ctx *cli.Context) ContextFlagsZeroBalanceSysAcc {
+	flagsConfig := ContextFlagsZeroBalanceSysAcc{}
+
+	flagsConfig.WorkingDir = ctx.GlobalString(trieToolsCommon.WorkingDirectory.Name)
+	flagsConfig.LogLevel = ctx.GlobalString(trieToolsCommon.LogLevel.Name)
+	flagsConfig.SaveLogFile = ctx.GlobalBool(trieToolsCommon.LogSaveFile.Name)
+	flagsConfig.EnableLogName = ctx.GlobalBool(trieToolsCommon.LogWithLoggerName.Name)
+	flagsConfig.EnablePprof = ctx.GlobalBool(trieToolsCommon.ProfileMode.Name)
+	flagsConfig.tokensDirectory = ctx.GlobalString(tokensDirectory.Name)
+
+	return flagsConfig
+}

--- a/trieTools/zeroBalanceSystemAccountChecker/main.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/main.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"fmt"
+	logger "github.com/ElrondNetwork/elrond-go-logger"
+	elrondFactory "github.com/ElrondNetwork/elrond-go/cmd/node/factory"
+	"github.com/ElrondNetwork/elrond-go/common/logging"
+	"github.com/ElrondNetwork/elrond-tools-go/trieTools/trieToolsCommon"
+	"github.com/urfave/cli"
+	"os"
+)
+
+const (
+	defaultLogsPath = "logs"
+	logFilePrefix   = "accounts-tokens-exporter"
+	outputFileName  = "output.json"
+	outputFilePerms = 0644
+)
+
+func main() {
+	app := cli.NewApp()
+	app.Name = "Tokens exporter CLI app"
+	app.Usage = "This is the entry point for the tool that exports all tokens for a given root hash"
+	app.Flags = getFlags()
+	app.Authors = []cli.Author{
+		{
+			Name:  "The Elrond Team",
+			Email: "contact@elrond.com",
+		},
+	}
+
+	app.Action = func(c *cli.Context) error {
+		return startProcess(c)
+	}
+
+	err := app.Run(os.Args)
+	if err != nil {
+		log.Error(err.Error())
+		os.Exit(1)
+		return
+	}
+
+	log.Info("finished exporting address-tokens map")
+}
+
+func startProcess(c *cli.Context) error {
+	flagsConfig := getFlagsConfig(c)
+
+	_, errLogger := attachFileLogger(log, flagsConfig.ContextFlagsConfig)
+	if errLogger != nil {
+		return errLogger
+	}
+
+	log.Info("sanity checks...")
+
+	err := logger.SetLogLevel(flagsConfig.LogLevel)
+	if err != nil {
+		return err
+	}
+
+	log.Info("starting processing trie", "pid", os.Getpid())
+
+	return exportZeroTokensBalances()
+}
+
+func attachFileLogger(log logger.Logger, flagsConfig trieToolsCommon.ContextFlagsConfig) (elrondFactory.FileLoggingHandler, error) {
+	var fileLogging elrondFactory.FileLoggingHandler
+	var err error
+	if flagsConfig.SaveLogFile {
+		fileLogging, err = logging.NewFileLogging(logging.ArgsFileLogging{
+			WorkingDir:      flagsConfig.WorkingDir,
+			DefaultLogsPath: defaultLogsPath,
+			LogFilePrefix:   logFilePrefix,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("%w creating a log file", err)
+		}
+	}
+
+	err = logger.SetDisplayByteSlice(logger.ToHex)
+	log.LogIfError(err)
+	logger.ToggleLoggerName(flagsConfig.EnableLogName)
+	logLevelFlagValue := flagsConfig.LogLevel
+	err = logger.SetLogLevel(logLevelFlagValue)
+	if err != nil {
+		return nil, err
+	}
+
+	if flagsConfig.DisableAnsiColor {
+		err = logger.RemoveLogObserver(os.Stdout)
+		if err != nil {
+			return nil, err
+		}
+
+		err = logger.AddLogObserver(os.Stdout, &logger.PlainFormatter{})
+		if err != nil {
+			return nil, err
+		}
+	}
+	log.Trace("logger updated", "level", logLevelFlagValue, "disable ANSI color", flagsConfig.DisableAnsiColor)
+
+	return fileLogging, nil
+}
+
+func exportZeroTokensBalances() error {
+	return nil
+}

--- a/trieTools/zeroBalanceSystemAccountChecker/vars.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/vars.go
@@ -1,0 +1,7 @@
+package main
+
+import (
+	logger "github.com/ElrondNetwork/elrond-go-logger"
+)
+
+var log = logger.GetOrCreate("main")


### PR DESCRIPTION
Description
--

- Created tool that exports **all tokens(with nonce)** that are stored in system account, but not in any other address( <=> tokens with 0 balance/supply in any other account)
- This tool reads multiple maps <address, tokens> from each shard(input is expected to be json files, as the ones exported by `tokensExporter` tool. see [this PR description](https://github.com/ElrondNetwork/elrond-tools-go/pull/19)) . Then, it merges all maps in a single one and checks which tokens are only found in system account, but not in any other address.
- If called with flag `--cross-check`, before exporting the final tokens list, it will **cross check the results** by:
1. Checking if token is stored in indexer. If found; check indexer addresses which hold this token. For each address that supposedly holds the token, check step 2.
2. Check if token exists in address's data trie(gateway call). If it exists; then this token will not be exported. Otherwise, we export the token and consider it to be an indexer issue=> log a warning.
- Since **we use multi search queries in indexer (10.000 queries/request)**(which are not public), I've added `config.toml` which should be filled with credentials


How to use it
--

- This tool exports map < tokens > in json format **after reading input data frum multiple shards**. Therefore, after preparing the input(using  [the tool mentioned above](https://github.com/ElrondNetwork/elrond-tools-go/pull/19)), you should create an `input` folder with data from each shard.


Example
--
-> Input directory
|
|--`input`---| ->`shrad0.json` -> store here `tokensExporter`' s tool output for **shard0**
|________ |-->`shrad1.json` -> store here `tokensExporter`' s tool output for **shard1**
|________ |-->`shrad2.json` -> store here `tokensExporter`' s tool output for **shard2**
|

-> **Run**:
`
./zeroBalanceSystemAccountChecker --tokens-dir input --outfile=extraTokens.json --cross-check
`

-> **If called with `--cross-check` flag**:

- If a token is found in indexer:
`
[DEBUG]   found token in indexer with hits/accounts token =  MEXFARML-28d646-19e103 hits/accounts = 1 
`
`
[DEBUG]   checking gateway if token still exists in trie  token = MEXFARML-28d646-19e103 address = erd1qqqqqqqqqqqqqpgqrc4pg2xarca9z34njcxeur622qmfjp8w2jps89fxnl 
`

There are two possibilites:
1. Indexer problem => one will see a  `WARN` log
`
[WARN]   possible indexer problem                 token = MEXFARML-28d646-19e103 hit in address = erd1qqqqqqqqqqqqqpgqrc4pg2xarca9z34njcxeur622qmfjp8w2jps89fxnl found in trie = false 
`
2. Snapshot problem => token still exists => one will see an `ERROR` log
`
[ERROR]   cross-check failed; found token which is still in other address token = MEXFARML-28d646-19e103 balance  = 6059787621742865721045753 address = erd1qqqqqqqqqqqqqpgq8xwzu82v8ex3h4ayl5lsvxqxnhecpwyvwe0sf2qj4e 
`

At the end, one should see an output like this:

`
[ERROR]   found tokens with balances that still exist in other accounts; probably found in pending mbs during snapshot; will remove them from exported tokens  tokens= [LKFARM-9d1ea8-860984 HOKI-518891-0535 MAFIA-bd0abc-94 SYNTHS-6ba972-012b] 
`
`
[INFO]   writing result in                       file = extraTokens.json 
`
`
[INFO]   finished exporting zero balance tokens map 
`

-> **Output in `extraTokens.json` should look like**:
```
{
 "4444-55dbda-0f": {},
 "ADASTRA-9b336e-01": {},
 "ADASTRA-9b336e-02": {},
 "ADASTRA-9b336e-03": {},
 "AMOWNER-bce923-01": {},
 "APCCHAIN-048e55-01": {},
 "APCHAT-109c14-01": {},
 "APCHIREZ-44fc2f-01": {},
...
