### PR TITLE
System account zero balances checker

### DIFF
--- a/elasticreindexer/elastic/elasticClient.go
+++ b/elasticreindexer/elastic/elasticClient.go
@@ -60,6 +60,24 @@ func NewElasticClient(cfg config.ElasticInstanceConfig) (*esClient, error) {
 	}, nil
 }
 
+// GetMultiple queries a multi search and returns the responses
+func (esc *esClient) GetMultiple(index string, requests []string) ([]byte, error) {
+	var query string
+	for _, request := range requests {
+		query += "{}\n" + request + "\n"
+	}
+
+	res, err := esc.client.Msearch(
+		bytes.NewBuffer([]byte(query)),
+		esc.client.Msearch.WithIndex(index),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return getBytesFromResponse(res)
+}
+
 // GetCount returns the total number of documents available in the provided index
 func (esc *esClient) GetCount(index string) (uint64, error) {
 	res, err := esc.client.Count(

--- a/trieTools/go.mod
+++ b/trieTools/go.mod
@@ -6,7 +6,10 @@ require (
 	github.com/ElrondNetwork/elrond-go v1.3.35
 	github.com/ElrondNetwork/elrond-go-core v1.1.16-0.20220622092812-cc07c736c3b8
 	github.com/ElrondNetwork/elrond-go-logger v1.0.7
+	github.com/ElrondNetwork/elrond-tools-go/elasticreindexer v0.0.0-20220822122240-fd32ce986e4c
 	github.com/ElrondNetwork/elrond-vm-common v1.3.12
+	github.com/pelletier/go-toml v1.9.3
+	github.com/tidwall/gjson v1.14.0
 	github.com/urfave/cli v1.22.9
 )
 
@@ -16,16 +19,18 @@ require (
 	github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
 	github.com/denisbrodbeck/machineid v1.0.1 // indirect
+	github.com/elastic/go-elasticsearch/v7 v7.12.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.1 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/mr-tron/base58 v1.2.0 // indirect
-	github.com/pelletier/go-toml v1.9.3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/russross/blackfriday/v2 v2.0.1 // indirect
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20190318030020-c3a204f8e965 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.0 // indirect
 	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4 // indirect
 	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad // indirect
 	google.golang.org/protobuf v1.28.0 // indirect

--- a/trieTools/go.sum
+++ b/trieTools/go.sum
@@ -67,6 +67,8 @@ github.com/ElrondNetwork/elrond-go-logger v1.0.4/go.mod h1:e5D+c97lKUfFdAzFX7rrI
 github.com/ElrondNetwork/elrond-go-logger v1.0.5/go.mod h1:cBfgx0ST/CJx8jrxJSC5aiSrvkGzcnF7sK06RD8mFxQ=
 github.com/ElrondNetwork/elrond-go-logger v1.0.7 h1:Ldl1rVS0RGKc1IsW8jIaGCb6Zwei04gsMvyjL05X6mE=
 github.com/ElrondNetwork/elrond-go-logger v1.0.7/go.mod h1:cBfgx0ST/CJx8jrxJSC5aiSrvkGzcnF7sK06RD8mFxQ=
+github.com/ElrondNetwork/elrond-tools-go/elasticreindexer v0.0.0-20220822122240-fd32ce986e4c h1:sw9RPJ/9pof/kdc4qsAPkRmpO1ZIwN3jCgUKINBJob8=
+github.com/ElrondNetwork/elrond-tools-go/elasticreindexer v0.0.0-20220822122240-fd32ce986e4c/go.mod h1:tdcxQ73bFf0JQLcpFmZ8E0mONYEErTV1mEG6IFlgtjQ=
 github.com/ElrondNetwork/elrond-vm-common v1.1.0/go.mod h1:w3i6f8uiuRkE68Ie/gebRcLgTuHqvruJSYrFyZWuLrE=
 github.com/ElrondNetwork/elrond-vm-common v1.2.9/go.mod h1:B/Y8WiqHyDd7xsjNYsaYbVMp1jQgQ+z4jTJkFvj/EWI=
 github.com/ElrondNetwork/elrond-vm-common v1.3.4/go.mod h1:B/Y8WiqHyDd7xsjNYsaYbVMp1jQgQ+z4jTJkFvj/EWI=
@@ -199,6 +201,8 @@ github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5m
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
+github.com/elastic/go-elasticsearch/v7 v7.11.0/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
+github.com/elastic/go-elasticsearch/v7 v7.12.0 h1:j4tvcMrZJLp39L2NYvBb7f+lHKPqPHSL3nvB8+/DV+s=
 github.com/elastic/go-elasticsearch/v7 v7.12.0/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
 github.com/elastic/gosigar v0.12.0/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
 github.com/elastic/gosigar v0.14.2/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
@@ -1041,8 +1045,14 @@ github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpP
 github.com/syndtr/goleveldb v1.0.1-0.20190318030020-c3a204f8e965 h1:1oFLiOyVl+W7bnBzGhf7BbIv9loSFQcieWWYIjLqcAw=
 github.com/syndtr/goleveldb v1.0.1-0.20190318030020-c3a204f8e965/go.mod h1:9OrXJhf154huy1nPWmuSrkgjPUtUNhA+Zmy+6AESzuA=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
+github.com/tidwall/gjson v1.8.1/go.mod h1:5/xDoumyyDNerp2U36lyolv46b3uF/9Bu6OfyQ9GImk=
+github.com/tidwall/gjson v1.14.0 h1:6aeJ0bzojgWLa82gDQHcx3S0Lr/O51I9bJ5nv6JFx5w=
 github.com/tidwall/gjson v1.14.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.0.3/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
 github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.1.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
+github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tklauser/go-sysconf v0.3.4/go.mod h1:Cl2c8ZRWfHD5IrfHo9VN+FX9kCFjIOyVklgXycLB6ek=
 github.com/tklauser/numcpus v0.2.1/go.mod h1:9aU+wOc6WjUIZEwWMP62PL/41d65P+iks1gBkr4QyP8=

--- a/trieTools/zeroBalanceSystemAccountChecker/config.toml
+++ b/trieTools/zeroBalanceSystemAccountChecker/config.toml
@@ -1,0 +1,8 @@
+[config]
+    [config.elasticIndexerConfig]
+        url = ""
+        username = ""
+        password = ""
+
+    [config.gateway]
+        url = "https://gateway.elrond.com"

--- a/trieTools/zeroBalanceSystemAccountChecker/config/config.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/config/config.go
@@ -1,0 +1,34 @@
+package config
+
+import "github.com/ElrondNetwork/elrond-tools-go/trieTools/trieToolsCommon"
+
+// ContextFlagsZeroBalanceSysAccChecker holds all flags required for zeroBalanceSystemAccountChecker tool
+type ContextFlagsZeroBalanceSysAccChecker struct {
+	trieToolsCommon.ContextFlagsConfig
+	TokensDirectory string
+	Outfile         string
+	CrossCheck      bool
+}
+
+// GeneralConfig holds general configs required for zeroBalanceSystemAccountChecker tool if cross check is flag is activated
+type GeneralConfig struct {
+	Config Config `toml:"config"`
+}
+
+// Config holds configs required for zeroBalanceSystemAccountChecker tool if cross check is flag is activated
+type Config struct {
+	ElasticIndexerConfig ElasticIndexerConfig `toml:"elasticIndexerConfig"`
+	Gateway              Gateway              `toml:"gateway"`
+}
+
+// ElasticIndexerConfig holds the configuration needed for connecting to an Elasticsearch instance
+type ElasticIndexerConfig struct {
+	URL      string `toml:"url"`
+	Username string `toml:"username"`
+	Password string `toml:"password"`
+}
+
+// Gateway holds the configuration needed to cross-check address-token trie
+type Gateway struct {
+	URL string `toml:"url"`
+}

--- a/trieTools/zeroBalanceSystemAccountChecker/extraTokensCrossChecker.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/extraTokensCrossChecker.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"errors"
+	"github.com/ElrondNetwork/elrond-go-core/core"
+	"github.com/tidwall/gjson"
+)
+
+const (
+	maxRequestsRetrial = 10
+	multipleSearchBulk = 10000
+)
+
+type nftBalancesGetter interface {
+	getBalance(address, token string) (string, error)
+}
+
+type elasticMultiSearchClient interface {
+	GetMultiple(index string, requests []string) ([]byte, error)
+}
+
+type extraTokensChecker struct {
+	nftBalancesGetter nftBalancesGetter
+	elasticClient     elasticMultiSearchClient
+}
+
+func newExtraTokensCrossChecker(client elasticMultiSearchClient, nftBalancesGetter nftBalancesGetter) (crossTokenChecker, error) {
+	if client == nil {
+		return nil, errors.New("nil elastic client provided")
+	}
+	if nftBalancesGetter == nil {
+		return nil, errors.New("nil nft balances getter provided")
+	}
+
+	return &extraTokensChecker{
+		nftBalancesGetter: nftBalancesGetter,
+		elasticClient:     client,
+	}, nil
+}
+
+func (etc *extraTokensChecker) crossCheckExtraTokens(tokens map[string]struct{}) ([]string, error) {
+	numTokens := len(tokens)
+	log.Info("starting to cross-check", "num of tokens", numTokens)
+
+	bulkSize := core.MinInt(multipleSearchBulk, numTokens)
+	tokensThatStillExist := make([]string, 0)
+	requests := make([]string, 0, bulkSize)
+	currTokenIdx := 0
+	ctRequests := 0
+	for token := range tokens {
+		currTokenIdx++
+		requests = append(requests, createRequest(token))
+
+		notEnoughRequests := len(requests) < bulkSize
+		notLastBulk := currTokenIdx != numTokens
+		if notEnoughRequests && notLastBulk {
+			continue
+		}
+
+		respBytes, err := etc.elasticClient.GetMultiple("accountsesdt", requests)
+		if err != nil {
+			log.Error("elasticClient.GetMultiple(accountsesdt, requests)",
+				"error", err,
+				"requests", requests)
+			return nil, err
+		}
+
+		responses := gjson.Get(string(respBytes), "responses").Array()
+		tokensThatStillExistFromRequest, err := etc.checkIndexerResponse(requests, responses)
+		if err != nil {
+			return nil, err
+		}
+
+		go printProgress(numTokens, currTokenIdx)
+
+		ctRequests += len(requests)
+		requests = make([]string, 0, bulkSize)
+		tokensThatStillExist = append(tokensThatStillExist, tokensThatStillExistFromRequest...)
+	}
+
+	log.Info("finished cross-checking",
+		"total num of tokens", numTokens,
+		"total num of tokens cross-checked", currTokenIdx,
+		"total num of tokens requests in indexer", ctRequests)
+
+	if numTokens != currTokenIdx || numTokens != ctRequests {
+		return nil, errors.New("failed to cross check all tokens, check logs")
+	}
+
+	return tokensThatStillExist, nil
+}
+
+func (etc *extraTokensChecker) checkIndexerResponse(requests []string, responses []gjson.Result) ([]string, error) {
+	tokensThatStillExist := make([]string, 0)
+	for idxRequestedToken, res := range responses {
+		hits := res.Get("hits.hits").Array()
+		if len(hits) != 0 {
+			token := gjson.Get(requests[idxRequestedToken], "query.match.identifier.query").String()
+			log.Debug("found token in indexer with hits/accounts",
+				"token", token,
+				"num hits/accounts", len(hits))
+
+			tokenExists, err := etc.crossCheckToken(hits, token)
+			if err != nil {
+				return nil, err
+			}
+
+			if tokenExists {
+				tokensThatStillExist = append(tokensThatStillExist, token)
+			}
+		}
+		idxRequestedToken++
+	}
+
+	return tokensThatStillExist, nil
+}
+
+func (etc *extraTokensChecker) crossCheckToken(hits []gjson.Result, token string) (bool, error) {
+	tokenExists := false
+	for _, hit := range hits {
+		address := hit.Get("_source.address").String()
+		balance, err := etc.nftBalancesGetter.getBalance(address, token)
+		if err != nil {
+			return false, err
+		}
+
+		log.Debug("checking gateway if token still exists in trie",
+			"token", token,
+			"address", address)
+
+		if balance != "0" {
+			tokenExists = true
+			log.Error("cross-check failed; found token which is still in other address",
+				"token", token,
+				"balance", balance,
+				"address", address)
+			break
+		}
+
+		log.Warn("possible indexer problem",
+			"token", token,
+			"hit in address", address,
+			"found in trie", false)
+	}
+
+	return tokenExists, nil
+}
+
+func createRequest(token string) string {
+	return `{"query" : {"match" : { "identifier": {"query":"` + token + `","operator":"and"}}}}`
+}
+
+func printProgress(numTokens, numTokensCrossChecked int) {
+	log.Info("status",
+		"num cross checked tokens", numTokensCrossChecked,
+		"remaining num of tokens to check", numTokens-numTokensCrossChecked,
+		"progress(%)", (100*numTokensCrossChecked)/numTokens) // this should not panic with div by zero, since func is only called if numTokens > 0
+}

--- a/trieTools/zeroBalanceSystemAccountChecker/flags.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/flags.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"github.com/ElrondNetwork/elrond-tools-go/trieTools/trieToolsCommon"
+	"github.com/ElrondNetwork/elrond-tools-go/trieTools/zeroBalanceSystemAccountChecker/config"
+	"github.com/urfave/cli"
+)
+
+var (
+	tokensDirectory = cli.StringFlag{
+		Name:  "tokens-dir",
+		Usage: "This flag specifies the `directory` where the application will find all exported tokens from all shards. For each file, it expects the input to be a map<address,tokens>",
+		Value: "in",
+	}
+
+	outfile = cli.StringFlag{
+		Name:  "outfile",
+		Usage: "This flag specifies where the output will be stored. It consists of a map<tokens>",
+		Value: "output.json",
+	}
+
+	crossCheck = cli.BoolFlag{
+		Name:  "cross-check",
+		Usage: "This flag specifies if a cross check for zero balances result should be done. If set, checks indexer storage using API calls, so it might take a while.",
+	}
+)
+
+func getFlags() []cli.Flag {
+	return []cli.Flag{
+		trieToolsCommon.LogLevel,
+		trieToolsCommon.DisableAnsiColor,
+		trieToolsCommon.LogSaveFile,
+		trieToolsCommon.LogWithLoggerName,
+		trieToolsCommon.ProfileMode,
+		tokensDirectory,
+		outfile,
+		crossCheck,
+	}
+}
+
+func getFlagsConfig(ctx *cli.Context) config.ContextFlagsZeroBalanceSysAccChecker {
+	flagsConfig := config.ContextFlagsZeroBalanceSysAccChecker{}
+
+	flagsConfig.LogLevel = ctx.GlobalString(trieToolsCommon.LogLevel.Name)
+	flagsConfig.SaveLogFile = ctx.GlobalBool(trieToolsCommon.LogSaveFile.Name)
+	flagsConfig.EnableLogName = ctx.GlobalBool(trieToolsCommon.LogWithLoggerName.Name)
+	flagsConfig.EnablePprof = ctx.GlobalBool(trieToolsCommon.ProfileMode.Name)
+	flagsConfig.TokensDirectory = ctx.GlobalString(tokensDirectory.Name)
+	flagsConfig.Outfile = ctx.GlobalString(outfile.Name)
+	flagsConfig.CrossCheck = ctx.GlobalBool(crossCheck.Name)
+
+	return flagsConfig
+}

--- a/trieTools/zeroBalanceSystemAccountChecker/main.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/main.go
@@ -1,0 +1,305 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/ElrondNetwork/elrond-go-core/core/pubkeyConverter"
+	logger "github.com/ElrondNetwork/elrond-go-logger"
+	"github.com/ElrondNetwork/elrond-tools-go/elasticreindexer/config"
+	"github.com/ElrondNetwork/elrond-tools-go/elasticreindexer/elastic"
+	sysAccConfig "github.com/ElrondNetwork/elrond-tools-go/trieTools/zeroBalanceSystemAccountChecker/config"
+	"github.com/pelletier/go-toml"
+	"github.com/urfave/cli"
+
+	"github.com/ElrondNetwork/elrond-tools-go/trieTools/trieToolsCommon"
+	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
+	"io/fs"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	logFilePrefix   = "system-account-zero-tokens-balance-checker"
+	addressLength   = 32
+	outputFilePerms = 0644
+	tomlFile        = "./config.toml"
+)
+
+type crossTokenChecker interface {
+	crossCheckExtraTokens(tokens map[string]struct{}) ([]string, error)
+}
+
+func main() {
+	app := cli.NewApp()
+	app.Name = "Tokens exporter CLI app"
+	app.Usage = "This is the entry point for the tool that checks which tokens are not used anymore(only stored in system account)"
+	app.Flags = getFlags()
+	app.Authors = []cli.Author{
+		{
+			Name:  "The Elrond Team",
+			Email: "contact@elrond.com",
+		},
+	}
+
+	app.Action = func(c *cli.Context) error {
+		return startProcess(c)
+	}
+
+	err := app.Run(os.Args)
+	if err != nil {
+		log.Error(err.Error())
+		os.Exit(1)
+		return
+	}
+}
+
+func startProcess(c *cli.Context) error {
+	flagsConfig := getFlagsConfig(c)
+
+	_, errLogger := trieToolsCommon.AttachFileLogger(log, logFilePrefix, flagsConfig.ContextFlagsConfig)
+	if errLogger != nil {
+		return errLogger
+	}
+
+	log.Info("sanity checks...")
+
+	err := logger.SetLogLevel(flagsConfig.LogLevel)
+	if err != nil {
+		return err
+	}
+
+	log.Info("starting processing trie", "pid", os.Getpid())
+
+	addressTokensMap, err := readInputs(flagsConfig.TokensDirectory)
+	if err != nil {
+		return err
+	}
+
+	extraTokens, err := exportSystemAccZeroTokensBalances(addressTokensMap)
+	if err != nil {
+		return err
+	}
+
+	if flagsConfig.CrossCheck {
+		err = crossCheckExtraTokens(extraTokens)
+		if err != nil {
+			return err
+		}
+	}
+
+	err = saveResult(extraTokens, flagsConfig.Outfile)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func readInputs(tokensDir string) (map[string]map[string]struct{}, error) {
+	workingDir, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+
+	fullPath := filepath.Join(workingDir, tokensDir)
+	contents, err := ioutil.ReadDir(fullPath)
+	if err != nil {
+		return nil, err
+	}
+
+	allAddressesTokensMap := make(map[string]map[string]struct{})
+	for _, file := range contents {
+		if file.IsDir() {
+			continue
+		}
+
+		addressTokensMapInCurrFile, err := getFileContent(filepath.Join(fullPath, file.Name()))
+		if err != nil {
+			return nil, err
+		}
+
+		merge(allAddressesTokensMap, addressTokensMapInCurrFile)
+		log.Info("read data from",
+			"file", file.Name(),
+			"num addresses in current file", len(addressTokensMapInCurrFile),
+			"num addresses in total, after merge", len(allAddressesTokensMap))
+	}
+
+	return allAddressesTokensMap, nil
+}
+
+func getFileContent(file string) (map[string]map[string]struct{}, error) {
+	jsonFile, err := os.Open(file)
+	if err != nil {
+		return nil, err
+	}
+
+	bytesFromJson, err := ioutil.ReadAll(jsonFile)
+	if err != nil {
+		return nil, err
+	}
+
+	addressTokensMapInCurrFile := make(map[string]map[string]struct{})
+	err = json.Unmarshal(bytesFromJson, &addressTokensMapInCurrFile)
+	if err != nil {
+		return nil, err
+	}
+
+	return addressTokensMapInCurrFile, nil
+}
+
+func merge(dest, src map[string]map[string]struct{}) {
+	for addressSrc, tokensSrc := range src {
+		_, existsInDest := dest[addressSrc]
+		if !existsInDest {
+			dest[addressSrc] = tokensSrc
+		} else {
+			log.Debug("same address found in multiple files", "address", addressSrc)
+			addTokensInDestAddress(tokensSrc, dest, addressSrc)
+		}
+	}
+}
+
+func addTokensInDestAddress(tokens map[string]struct{}, dest map[string]map[string]struct{}, address string) {
+	for token := range tokens {
+		dest[address][token] = struct{}{}
+	}
+}
+
+func exportSystemAccZeroTokensBalances(allAddressesTokensMap map[string]map[string]struct{}) (map[string]struct{}, error) {
+	addressConverter, err := pubkeyConverter.NewBech32PubkeyConverter(addressLength, log)
+	if err != nil {
+		return nil, err
+	}
+
+	systemSCAddress := addressConverter.Encode(vmcommon.SystemAccountAddress)
+	allTokensInSystemSCAddress, foundSystemSCAddress := allAddressesTokensMap[systemSCAddress]
+	if !foundSystemSCAddress {
+		return nil, fmt.Errorf("no system account address(%s) found", systemSCAddress)
+	}
+
+	allTokens := getAllTokensWithoutSystemAccount(allAddressesTokensMap, systemSCAddress)
+	log.Info("found",
+		"total num of tokens in all addresses", len(allTokens),
+		"total num of tokens in system sc address", len(allTokensInSystemSCAddress))
+
+	return getExtraTokens(allTokens, allTokensInSystemSCAddress), nil
+}
+
+func getAllTokensWithoutSystemAccount(allAddressesTokensMap map[string]map[string]struct{}, systemSCAddress string) map[string]struct{} {
+	delete(allAddressesTokensMap, systemSCAddress)
+
+	allTokens := make(map[string]struct{})
+	for _, tokens := range allAddressesTokensMap {
+		for token := range tokens {
+			allTokens[token] = struct{}{}
+		}
+	}
+
+	return allTokens
+}
+
+func getExtraTokens(allTokens, allTokensInSystemSCAddress map[string]struct{}) map[string]struct{} {
+	ctTokensOnlyInSystemAcc := 0
+	extraTokens := make(map[string]struct{})
+	for tokenInSystemSC := range allTokensInSystemSCAddress {
+		_, exists := allTokens[tokenInSystemSC]
+		if !exists {
+			ctTokensOnlyInSystemAcc++
+			addTokenInMapIfHasNonce(tokenInSystemSC, extraTokens)
+		}
+	}
+
+	log.Info("found",
+		"num tokens in system account, but not in any other address", ctTokensOnlyInSystemAcc,
+		"num of sfts/nfts/metaesdts metadata only found in system sc address", len(extraTokens))
+
+	return extraTokens
+}
+
+func addTokenInMapIfHasNonce(token string, tokens map[string]struct{}) {
+	if hasNonce(token) {
+		tokens[token] = struct{}{}
+	}
+}
+
+func hasNonce(token string) bool {
+	return strings.Count(token, "-") == 2
+}
+
+func saveResult(tokens map[string]struct{}, outfile string) error {
+	jsonBytes, err := json.MarshalIndent(tokens, "", " ")
+	if err != nil {
+		return err
+	}
+
+	log.Info("writing result in", "file", outfile)
+	err = ioutil.WriteFile(outfile, jsonBytes, fs.FileMode(outputFilePerms))
+	if err != nil {
+		return err
+	}
+
+	log.Info("finished exporting zero balance tokens map")
+	return nil
+}
+
+func crossCheckExtraTokens(extraTokens map[string]struct{}) error {
+	cfg, err := loadConfig()
+	if err != nil {
+		return err
+	}
+
+	nftGetter := newNFTBalanceGetter(cfg.Config.Gateway.URL)
+	elasticClient, err := elastic.NewElasticClient(config.ElasticInstanceConfig{
+		URL:      cfg.Config.ElasticIndexerConfig.URL,
+		Username: cfg.Config.ElasticIndexerConfig.Username,
+		Password: cfg.Config.ElasticIndexerConfig.Password,
+	})
+	if err != nil {
+		return err
+	}
+
+	tokensChecker, err := newExtraTokensCrossChecker(elasticClient, nftGetter)
+	if err != nil {
+		return err
+	}
+
+	tokensThatStillExist, err := tokensChecker.crossCheckExtraTokens(extraTokens)
+	if err != nil {
+		return err
+	}
+
+	removeTokensThatStillExist(tokensThatStillExist, extraTokens)
+	return nil
+}
+
+func loadConfig() (*sysAccConfig.GeneralConfig, error) {
+	tomlBytes, err := ioutil.ReadFile(tomlFile)
+	if err != nil {
+		return nil, err
+	}
+
+	var tc sysAccConfig.GeneralConfig
+	err = toml.Unmarshal(tomlBytes, &tc)
+	if err != nil {
+		return nil, err
+	}
+
+	return &tc, nil
+}
+
+func removeTokensThatStillExist(tokensThatStillExist []string, tokens map[string]struct{}) {
+	if len(tokensThatStillExist) == 0 {
+		log.Info("all cross-checks were successful; exported tokens are only stored in system account")
+		return
+	}
+
+	log.Error("found tokens with balances that still exist in other accounts; probably found in pending mbs during snapshot; will remove them from exported tokens",
+		"tokens", tokensThatStillExist)
+
+	for _, token := range tokensThatStillExist {
+		delete(tokens, token)
+	}
+}

--- a/trieTools/zeroBalanceSystemAccountChecker/nftBalanceGetter.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/nftBalanceGetter.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"fmt"
+	"github.com/tidwall/gjson"
+	"io"
+	"math/big"
+	"net/http"
+	"strings"
+)
+
+type nftBalanceGetter struct {
+	proxyURL string
+}
+
+func newNFTBalanceGetter(proxyURL string) *nftBalanceGetter {
+	return &nftBalanceGetter{
+		proxyURL: proxyURL,
+	}
+}
+
+func (eg *nftBalanceGetter) getBalance(address, token string) (string, error) {
+	tokenID, nonce := getTokenIDAndNonce(token)
+	return eg.fetchNFTBalanceWithRetrial(address, tokenID, nonce)
+}
+
+func getTokenIDAndNonce(token string) (string, uint64) {
+	tokens := strings.Split(token, "-")
+	tokenID := tokens[0] + "-" + tokens[1]
+
+	nonce := big.NewInt(0)
+	nonce.SetString(tokens[2], 16)
+
+	return tokenID, nonce.Uint64()
+}
+
+func (eg *nftBalanceGetter) fetchNFTBalanceWithRetrial(address, tokenID string, nonce uint64) (string, error) {
+	ctRetrials := 0
+
+	for ctRetrials < maxRequestsRetrial {
+		url := fmt.Sprintf("%s/address/%s/nft/%s/nonce/%d", eg.proxyURL, address, tokenID, nonce)
+		resp, errHttp := http.Get(url)
+		body, errBody := eg.getBody(resp)
+		if errHttp == nil && errBody == nil {
+			return gjson.Get(body, "data.tokenData.balance").String(), nil
+		}
+
+		log.Warn("could not get balance; retrying...",
+			"address", address,
+			"tokenID", tokenID,
+			"token nonce", nonce,
+			"error http", errHttp,
+			"error body", errBody,
+			"num retrials", ctRetrials)
+
+		ctRetrials++
+	}
+
+	return "", fmt.Errorf("could not get adress's tokens = %s after num of retrials = %d", address, maxRequestsRetrial)
+}
+
+func (eg *nftBalanceGetter) getBody(response *http.Response) (string, error) {
+	bodyBytes, err := io.ReadAll(response.Body)
+	if err != nil {
+		return "", fmt.Errorf("could not ready bytes from body; error: %w", err)
+	}
+
+	bodyStr := string(bodyBytes)
+	bodyErr := gjson.Get(bodyStr, "error").String()
+	if len(bodyErr) != 0 {
+		return "", fmt.Errorf("got error in body response when getting esdt tokens, proxy url: %s, body error: %s", eg.proxyURL, bodyErr)
+	}
+
+	return string(bodyBytes), nil
+}

--- a/trieTools/zeroBalanceSystemAccountChecker/vars.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/vars.go
@@ -1,0 +1,7 @@
+package main
+
+import (
+	logger "github.com/ElrondNetwork/elrond-go-logger"
+)
+
+var log = logger.GetOrCreate("main")


### PR DESCRIPTION
Description
--

- Created tool that exports **all tokens(with nonce)** that are stored in system account, but not in any other address( <=> tokens with 0 balance/supply in any other account)
- This tool reads multiple maps <address, tokens> from each shard(input is expected to be json files, as the ones exported by `tokensExporter` tool. see [this PR description](https://github.com/ElrondNetwork/elrond-tools-go/pull/19)) . Then, it merges all maps in a single one and checks which tokens are only found in system account, but not in any other address.
- If called with flag `--cross-check`, before exporting the final tokens list, it will **cross check the results** by:
1. Checking if token is stored in indexer. If found; check indexer addresses which hold this token. For each address that supposedly holds the token, check step 2.
2. Check if token exists in address's data trie(gateway call). If it exists; then this token will not be exported. Otherwise, we export the token and consider it to be an indexer issue=> log a warning.
- Since **we use multi search queries in indexer (10.000 queries/request)**(which are not public), I've added `config.toml` which should be filled with credentials


How to use it
--

- This tool exports map < tokens > in json format **after reading input data frum multiple shards**. Therefore, after preparing the input(using  [the tool mentioned above](https://github.com/ElrondNetwork/elrond-tools-go/pull/19)), you should create an `input` folder with data from each shard.


Example
--
-> Input directory
|
|--`input`---| ->`shrad0.json` -> store here `tokensExporter`' s tool output for **shard0**
|________ |-->`shrad1.json` -> store here `tokensExporter`' s tool output for **shard1**
|________ |-->`shrad2.json` -> store here `tokensExporter`' s tool output for **shard2**
|

-> **Run**:
`
./zeroBalanceSystemAccountChecker --tokens-dir input --outfile=extraTokens.json --cross-check
`

-> **If called with `--cross-check` flag**:

- If a token is found in indexer:
`
[DEBUG]   found token in indexer with hits/accounts token =  MEXFARML-28d646-19e103 hits/accounts = 1 
`
`
[DEBUG]   checking gateway if token still exists in trie  token = MEXFARML-28d646-19e103 address = erd1qqqqqqqqqqqqqpgqrc4pg2xarca9z34njcxeur622qmfjp8w2jps89fxnl 
`

There are two possibilites:
1. Indexer problem => one will see a  `WARN` log
`
[WARN]   possible indexer problem                 token = MEXFARML-28d646-19e103 hit in address = erd1qqqqqqqqqqqqqpgqrc4pg2xarca9z34njcxeur622qmfjp8w2jps89fxnl found in trie = false 
`
2. Snapshot problem => token still exists => one will see an `ERROR` log
`
[ERROR]   cross-check failed; found token which is still in other address token = MEXFARML-28d646-19e103 balance  = 6059787621742865721045753 address = erd1qqqqqqqqqqqqqpgq8xwzu82v8ex3h4ayl5lsvxqxnhecpwyvwe0sf2qj4e 
`

At the end, one should see an output like this:

`
[ERROR]   found tokens with balances that still exist in other accounts; probably found in pending mbs during snapshot; will remove them from exported tokens  tokens= [LKFARM-9d1ea8-860984 HOKI-518891-0535 MAFIA-bd0abc-94 SYNTHS-6ba972-012b] 
`
`
[INFO]   writing result in                       file = extraTokens.json 
`
`
[INFO]   finished exporting zero balance tokens map 
`

-> **Output in `extraTokens.json` should look like**:
```
{
 "4444-55dbda-0f": {},
 "ADASTRA-9b336e-01": {},
 "ADASTRA-9b336e-02": {},
 "ADASTRA-9b336e-03": {},
 "AMOWNER-bce923-01": {},
 "APCCHAIN-048e55-01": {},
 "APCHAT-109c14-01": {},
 "APCHIREZ-44fc2f-01": {},
...
