### PR TITLE
Zero balance sys acc checker

### DIFF
--- a/elasticreindexer/elastic/elasticClient.go
+++ b/elasticreindexer/elastic/elasticClient.go
@@ -60,6 +60,24 @@ func NewElasticClient(cfg config.ElasticInstanceConfig) (*esClient, error) {
 	}, nil
 }
 
+// GetMultiple queries a multi search and returns the responses
+func (esc *esClient) GetMultiple(index string, requests []string) ([]byte, error) {
+	var query string
+	for _, request := range requests {
+		query += "{}\n" + request + "\n"
+	}
+
+	res, err := esc.client.Msearch(
+		bytes.NewBuffer([]byte(query)),
+		esc.client.Msearch.WithIndex(index),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return getBytesFromResponse(res)
+}
+
 // GetCount returns the total number of documents available in the provided index
 func (esc *esClient) GetCount(index string) (uint64, error) {
 	res, err := esc.client.Count(

--- a/trieTools/go.mod
+++ b/trieTools/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/ElrondNetwork/elrond-tools-go/elasticreindexer v0.0.0-20220822122240-fd32ce986e4c
 	github.com/ElrondNetwork/elrond-vm-common v1.3.12
 	github.com/pelletier/go-toml v1.9.3
+	github.com/stretchr/testify v1.8.0
 	github.com/tidwall/gjson v1.14.0
 	github.com/urfave/cli v1.22.9
 )
@@ -18,6 +19,7 @@ require (
 	github.com/ElrondNetwork/elrond-go-crypto v1.0.1 // indirect
 	github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/denisbrodbeck/machineid v1.0.1 // indirect
 	github.com/elastic/go-elasticsearch/v7 v7.12.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
@@ -26,6 +28,7 @@ require (
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/mr-tron/base58 v1.2.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/russross/blackfriday/v2 v2.0.1 // indirect
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20190318030020-c3a204f8e965 // indirect
@@ -34,6 +37,7 @@ require (
 	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4 // indirect
 	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad // indirect
 	google.golang.org/protobuf v1.28.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 replace github.com/gogo/protobuf => github.com/ElrondNetwork/protobuf v1.3.2

--- a/trieTools/go.mod
+++ b/trieTools/go.mod
@@ -6,7 +6,10 @@ require (
 	github.com/ElrondNetwork/elrond-go v1.3.35
 	github.com/ElrondNetwork/elrond-go-core v1.1.16-0.20220622092812-cc07c736c3b8
 	github.com/ElrondNetwork/elrond-go-logger v1.0.7
+	github.com/ElrondNetwork/elrond-tools-go/elasticreindexer v0.0.0-20220822122240-fd32ce986e4c
 	github.com/ElrondNetwork/elrond-vm-common v1.3.12
+	github.com/pelletier/go-toml v1.9.3
+	github.com/tidwall/gjson v1.14.0
 	github.com/urfave/cli v1.22.9
 )
 
@@ -16,16 +19,18 @@ require (
 	github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
 	github.com/denisbrodbeck/machineid v1.0.1 // indirect
+	github.com/elastic/go-elasticsearch/v7 v7.12.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.1 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/mr-tron/base58 v1.2.0 // indirect
-	github.com/pelletier/go-toml v1.9.3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/russross/blackfriday/v2 v2.0.1 // indirect
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20190318030020-c3a204f8e965 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.0 // indirect
 	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4 // indirect
 	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad // indirect
 	google.golang.org/protobuf v1.28.0 // indirect

--- a/trieTools/go.sum
+++ b/trieTools/go.sum
@@ -67,6 +67,8 @@ github.com/ElrondNetwork/elrond-go-logger v1.0.4/go.mod h1:e5D+c97lKUfFdAzFX7rrI
 github.com/ElrondNetwork/elrond-go-logger v1.0.5/go.mod h1:cBfgx0ST/CJx8jrxJSC5aiSrvkGzcnF7sK06RD8mFxQ=
 github.com/ElrondNetwork/elrond-go-logger v1.0.7 h1:Ldl1rVS0RGKc1IsW8jIaGCb6Zwei04gsMvyjL05X6mE=
 github.com/ElrondNetwork/elrond-go-logger v1.0.7/go.mod h1:cBfgx0ST/CJx8jrxJSC5aiSrvkGzcnF7sK06RD8mFxQ=
+github.com/ElrondNetwork/elrond-tools-go/elasticreindexer v0.0.0-20220822122240-fd32ce986e4c h1:sw9RPJ/9pof/kdc4qsAPkRmpO1ZIwN3jCgUKINBJob8=
+github.com/ElrondNetwork/elrond-tools-go/elasticreindexer v0.0.0-20220822122240-fd32ce986e4c/go.mod h1:tdcxQ73bFf0JQLcpFmZ8E0mONYEErTV1mEG6IFlgtjQ=
 github.com/ElrondNetwork/elrond-vm-common v1.1.0/go.mod h1:w3i6f8uiuRkE68Ie/gebRcLgTuHqvruJSYrFyZWuLrE=
 github.com/ElrondNetwork/elrond-vm-common v1.2.9/go.mod h1:B/Y8WiqHyDd7xsjNYsaYbVMp1jQgQ+z4jTJkFvj/EWI=
 github.com/ElrondNetwork/elrond-vm-common v1.3.4/go.mod h1:B/Y8WiqHyDd7xsjNYsaYbVMp1jQgQ+z4jTJkFvj/EWI=
@@ -199,6 +201,8 @@ github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5m
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
+github.com/elastic/go-elasticsearch/v7 v7.11.0/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
+github.com/elastic/go-elasticsearch/v7 v7.12.0 h1:j4tvcMrZJLp39L2NYvBb7f+lHKPqPHSL3nvB8+/DV+s=
 github.com/elastic/go-elasticsearch/v7 v7.12.0/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
 github.com/elastic/gosigar v0.12.0/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
 github.com/elastic/gosigar v0.14.2/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
@@ -1041,8 +1045,14 @@ github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpP
 github.com/syndtr/goleveldb v1.0.1-0.20190318030020-c3a204f8e965 h1:1oFLiOyVl+W7bnBzGhf7BbIv9loSFQcieWWYIjLqcAw=
 github.com/syndtr/goleveldb v1.0.1-0.20190318030020-c3a204f8e965/go.mod h1:9OrXJhf154huy1nPWmuSrkgjPUtUNhA+Zmy+6AESzuA=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
+github.com/tidwall/gjson v1.8.1/go.mod h1:5/xDoumyyDNerp2U36lyolv46b3uF/9Bu6OfyQ9GImk=
+github.com/tidwall/gjson v1.14.0 h1:6aeJ0bzojgWLa82gDQHcx3S0Lr/O51I9bJ5nv6JFx5w=
 github.com/tidwall/gjson v1.14.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.0.3/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
 github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.1.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
+github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tklauser/go-sysconf v0.3.4/go.mod h1:Cl2c8ZRWfHD5IrfHo9VN+FX9kCFjIOyVklgXycLB6ek=
 github.com/tklauser/numcpus v0.2.1/go.mod h1:9aU+wOc6WjUIZEwWMP62PL/41d65P+iks1gBkr4QyP8=

--- a/trieTools/go.sum
+++ b/trieTools/go.sum
@@ -1033,6 +1033,7 @@ github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271/go.mod h1:AZpEONHx3
 github.com/streadway/handy v0.0.0-20190108123426-d5acb3125c2a/go.mod h1:qNTQ5P5JnDBl6z3cMAg/SywNDC5ABu5ApDIw6lUbRmI=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
@@ -1041,6 +1042,8 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 github.com/syndtr/goleveldb v1.0.1-0.20190318030020-c3a204f8e965 h1:1oFLiOyVl+W7bnBzGhf7BbIv9loSFQcieWWYIjLqcAw=
 github.com/syndtr/goleveldb v1.0.1-0.20190318030020-c3a204f8e965/go.mod h1:9OrXJhf154huy1nPWmuSrkgjPUtUNhA+Zmy+6AESzuA=
@@ -1571,6 +1574,8 @@ gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 grpc.go4.org v0.0.0-20170609214715-11d0a25b4919/go.mod h1:77eQGdRu53HpSqPFJFmuJdjuHRquDANNeA4x7B8WQ9o=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/trieTools/tokensExporter/main.go
+++ b/trieTools/tokensExporter/main.go
@@ -149,7 +149,7 @@ func exportTokens(flags config.ContextFlagsTokensExporter, mainRootHash []byte, 
 	log.Info("parsed main trie",
 		"num accounts", numAccountsOnMainTrie,
 		"num accounts with tokens", len(addressTokensMap),
-		"num tokens in all accounts", getNumTokens(addressTokensMap),
+		"num tokens in all accounts", trieToolsCommon.GetNumTokens(addressTokensMap),
 		"num tokens in system account address", len(addressTokensMap[encodedSysAccAddress]))
 
 	_, found := addressTokensMap[encodedSysAccAddress]
@@ -172,17 +172,6 @@ func getAddress(kv core.KeyValueHolder) ([]byte, bool) {
 	}
 
 	return kv.Key(), true
-}
-
-func getNumTokens(addressTokensMap map[string]map[string]struct{}) uint64 {
-	numTokens := uint64(0)
-	for _, tokens := range addressTokensMap {
-		for range tokens {
-			numTokens++
-		}
-	}
-
-	return numTokens
 }
 
 func saveResult(addressTokensMap map[string]map[string]struct{}, outfile string) error {

--- a/trieTools/trieToolsCommon/addressTokens.go
+++ b/trieTools/trieToolsCommon/addressTokens.go
@@ -23,8 +23,7 @@ func (atm *addressTokensMap) Add(address string, tokens map[string]struct{}) {
 }
 
 func (atm *addressTokensMap) addTokens(address string, tokens map[string]struct{}) {
-	tokensCopy := copyTokens(tokens)
-	for token := range tokensCopy {
+	for token := range tokens {
 		atm.internalMap[address][token] = struct{}{}
 	}
 }

--- a/trieTools/trieToolsCommon/addressTokens.go
+++ b/trieTools/trieToolsCommon/addressTokens.go
@@ -18,7 +18,14 @@ func (atm *addressTokensMap) Add(address string, tokens map[string]struct{}) {
 		atm.internalMap[address] = make(map[string]struct{})
 	}
 
-	atm.internalMap[address] = copyTokens(tokens)
+	atm.addTokens(address, tokens)
+}
+
+func (atm *addressTokensMap) addTokens(address string, tokens map[string]struct{}) {
+	tokensCopy := copyTokens(tokens)
+	for token := range tokensCopy {
+		atm.internalMap[address][token] = struct{}{}
+	}
 }
 
 func copyTokens(tokens map[string]struct{}) map[string]struct{} {

--- a/trieTools/trieToolsCommon/addressTokens.go
+++ b/trieTools/trieToolsCommon/addressTokens.go
@@ -5,6 +5,7 @@ type addressTokensMap struct {
 	internalMap map[string]map[string]struct{}
 }
 
+// NewAddressTokensMap creates a new map<address, tokens> handler
 func NewAddressTokensMap() AddressTokensMap {
 	return &addressTokensMap{
 		internalMap: make(map[string]map[string]struct{}),
@@ -94,8 +95,8 @@ func (atm *addressTokensMap) GetAllTokens() map[string]struct{} {
 	return allTokens
 }
 
-// ShallowClone returns a shallow clone of the current object
-func (atm *addressTokensMap) ShallowClone() AddressTokensMap {
+// Clone returns a shallow clone of the current object
+func (atm *addressTokensMap) Clone() AddressTokensMap {
 	mapCopy := atm.GetMapCopy()
 	return &addressTokensMap{
 		internalMap: mapCopy,

--- a/trieTools/trieToolsCommon/addressTokens.go
+++ b/trieTools/trieToolsCommon/addressTokens.go
@@ -52,9 +52,7 @@ func (atm *addressTokensMap) NumAddresses() uint64 {
 func (atm *addressTokensMap) NumTokens() uint64 {
 	numTokens := uint64(0)
 	for _, tokens := range atm.internalMap {
-		for range tokens {
-			numTokens++
-		}
+		numTokens += uint64(len(tokens))
 	}
 
 	return numTokens

--- a/trieTools/trieToolsCommon/addressTokens.go
+++ b/trieTools/trieToolsCommon/addressTokens.go
@@ -1,0 +1,99 @@
+package trieToolsCommon
+
+type addressTokensMap struct {
+	internalMap map[string]map[string]struct{}
+}
+
+func NewAddressTokensMap() AddressTokensMap {
+	return &addressTokensMap{
+		internalMap: make(map[string]map[string]struct{}),
+	}
+}
+
+func (atm *addressTokensMap) Add(addr string, tokens map[string]struct{}) {
+	_, addressExists := atm.internalMap[addr]
+	if !addressExists {
+		atm.internalMap[addr] = tokens
+	} else {
+		atm.addTokens(addr, tokens)
+	}
+}
+
+func (atm *addressTokensMap) addTokens(addr string, tokens map[string]struct{}) {
+	for token := range tokens {
+		atm.internalMap[addr][token] = struct{}{}
+	}
+}
+
+func (atm *addressTokensMap) HasAddress(addr string) bool {
+	_, found := atm.internalMap[addr]
+	return found
+}
+
+func (atm *addressTokensMap) HasToken(addr string, token string) bool {
+	_, found := atm.internalMap[addr][token]
+	return found
+}
+
+func (atm *addressTokensMap) NumAddresses() uint64 {
+	return uint64(len(atm.internalMap))
+}
+
+func (atm *addressTokensMap) NumTokens() uint64 {
+	numTokens := uint64(0)
+	for _, tokens := range atm.internalMap {
+		for range tokens {
+			numTokens++
+		}
+	}
+
+	return numTokens
+}
+
+func (atm *addressTokensMap) GetMapCopy() map[string]map[string]struct{} {
+	addressTokensMapCopy := make(map[string]map[string]struct{})
+
+	for address, tokens := range atm.internalMap {
+		addressTokensMapCopy[address] = make(map[string]struct{})
+		for token := range tokens {
+			addressTokensMapCopy[address][token] = struct{}{}
+		}
+	}
+
+	return addressTokensMapCopy
+}
+
+func (atm *addressTokensMap) GetAddresses() map[string]struct{} {
+	ret := make(map[string]struct{})
+	for addr := range atm.internalMap {
+		ret[addr] = struct{}{}
+	}
+
+	return ret
+}
+
+func (atm *addressTokensMap) GetTokens(address string) map[string]struct{} {
+	return atm.internalMap[address]
+}
+
+func (atm *addressTokensMap) Delete(address string) {
+	delete(atm.internalMap, address)
+}
+
+func (atm *addressTokensMap) GetAllTokens() map[string]struct{} {
+	allTokens := make(map[string]struct{})
+	for _, tokens := range atm.internalMap {
+		for token := range tokens {
+			allTokens[token] = struct{}{}
+		}
+	}
+
+	return allTokens
+}
+
+func (atm *addressTokensMap) ShallowClone() AddressTokensMap {
+	mapCopy := atm.GetMapCopy()
+	return &addressTokensMap{
+		internalMap: mapCopy,
+	}
+}

--- a/trieTools/trieToolsCommon/common.go
+++ b/trieTools/trieToolsCommon/common.go
@@ -174,3 +174,14 @@ func NewAccountsAdapter(trie common.Trie) (state.AccountsAdapter, error) {
 
 	return accountsAdapter, err
 }
+
+func GetNumTokens(addressTokensMap map[string]map[string]struct{}) int {
+	numTokensInShard := 0
+	for _, tokens := range addressTokensMap {
+		for range tokens {
+			numTokensInShard++
+		}
+	}
+
+	return numTokensInShard
+}

--- a/trieTools/trieToolsCommon/common.go
+++ b/trieTools/trieToolsCommon/common.go
@@ -2,6 +2,11 @@ package trieToolsCommon
 
 import (
 	"fmt"
+	"io/ioutil"
+	"math/big"
+	"os"
+	"path"
+
 	logger "github.com/ElrondNetwork/elrond-go-logger"
 	elrondFactory "github.com/ElrondNetwork/elrond-go/cmd/node/factory"
 	"github.com/ElrondNetwork/elrond-go/common"
@@ -17,10 +22,6 @@ import (
 	"github.com/ElrondNetwork/elrond-go/testscommon"
 	"github.com/ElrondNetwork/elrond-go/trie"
 	"github.com/ElrondNetwork/elrond-tools-go/trieTools/trieToolsCommon/components"
-	"io/ioutil"
-	"math/big"
-	"os"
-	"path"
 )
 
 const (
@@ -175,6 +176,7 @@ func NewAccountsAdapter(trie common.Trie) (state.AccountsAdapter, error) {
 	return accountsAdapter, err
 }
 
+// GetNumTokens will return the number of tokens in the map
 func GetNumTokens(addressTokensMap map[string]map[string]struct{}) int {
 	numTokensInShard := 0
 	for _, tokens := range addressTokensMap {

--- a/trieTools/trieToolsCommon/interface.go
+++ b/trieTools/trieToolsCommon/interface.go
@@ -1,15 +1,14 @@
 package trieToolsCommon
 
+// AddressTokensMap should handle a map<address, tokens>
 type AddressTokensMap interface {
 	Add(addr string, tokens map[string]struct{})
 	Delete(address string)
-	GetAddresses() map[string]struct{}
 	GetAllTokens() map[string]struct{}
 	GetTokens(address string) map[string]struct{}
 	GetMapCopy() map[string]map[string]struct{}
 	ShallowClone() AddressTokensMap
 	HasAddress(addr string) bool
-	HasToken(addr string, token string) bool
 	NumAddresses() uint64
 	NumTokens() uint64
 }

--- a/trieTools/trieToolsCommon/interface.go
+++ b/trieTools/trieToolsCommon/interface.go
@@ -7,7 +7,7 @@ type AddressTokensMap interface {
 	GetAllTokens() map[string]struct{}
 	GetTokens(address string) map[string]struct{}
 	GetMapCopy() map[string]map[string]struct{}
-	ShallowClone() AddressTokensMap
+	Clone() AddressTokensMap
 	HasAddress(addr string) bool
 	NumAddresses() uint64
 	NumTokens() uint64

--- a/trieTools/trieToolsCommon/interface.go
+++ b/trieTools/trieToolsCommon/interface.go
@@ -1,0 +1,15 @@
+package trieToolsCommon
+
+type AddressTokensMap interface {
+	Add(addr string, tokens map[string]struct{})
+	Delete(address string)
+	GetAddresses() map[string]struct{}
+	GetAllTokens() map[string]struct{}
+	GetTokens(address string) map[string]struct{}
+	GetMapCopy() map[string]map[string]struct{}
+	ShallowClone() AddressTokensMap
+	HasAddress(addr string) bool
+	HasToken(addr string, token string) bool
+	NumAddresses() uint64
+	NumTokens() uint64
+}

--- a/trieTools/zeroBalanceSystemAccountChecker/common/interface.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/common/interface.go
@@ -1,0 +1,7 @@
+package common
+
+// FileInfo should provide basic information about a file
+type FileInfo interface {
+	Name() string
+	IsDir() bool
+}

--- a/trieTools/zeroBalanceSystemAccountChecker/config.toml
+++ b/trieTools/zeroBalanceSystemAccountChecker/config.toml
@@ -5,4 +5,4 @@
         password = ""
 
     [config.gateway]
-        url = "https://gateway.elrond.com"
+        url = ""

--- a/trieTools/zeroBalanceSystemAccountChecker/config.toml
+++ b/trieTools/zeroBalanceSystemAccountChecker/config.toml
@@ -1,0 +1,8 @@
+[config]
+    [config.elasticIndexerConfig]
+        url = ""
+        username = ""
+        password = ""
+
+    [config.gateway]
+        url = "https://gateway.elrond.com"

--- a/trieTools/zeroBalanceSystemAccountChecker/config/config.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/config/config.go
@@ -1,0 +1,34 @@
+package config
+
+import "github.com/ElrondNetwork/elrond-tools-go/trieTools/trieToolsCommon"
+
+// ContextFlagsZeroBalanceSysAccChecker holds all flags required for zeroBalanceSystemAccountChecker tool
+type ContextFlagsZeroBalanceSysAccChecker struct {
+	trieToolsCommon.ContextFlagsConfig
+	TokensDirectory string
+	Outfile         string
+	CrossCheck      bool
+}
+
+// GeneralConfig holds general configs required for zeroBalanceSystemAccountChecker tool if cross check is flag is activated
+type GeneralConfig struct {
+	Config Config `toml:"config"`
+}
+
+// Config holds configs required for zeroBalanceSystemAccountChecker tool if cross check is flag is activated
+type Config struct {
+	ElasticIndexerConfig ElasticIndexerConfig `toml:"elasticIndexerConfig"`
+	Gateway              Gateway              `toml:"gateway"`
+}
+
+// ElasticIndexerConfig holds the configuration needed for connecting to an Elasticsearch instance
+type ElasticIndexerConfig struct {
+	URL      string `toml:"url"`
+	Username string `toml:"username"`
+	Password string `toml:"password"`
+}
+
+// Gateway holds the configuration needed to cross-check address-token trie
+type Gateway struct {
+	URL string `toml:"url"`
+}

--- a/trieTools/zeroBalanceSystemAccountChecker/extraTokensCrossChecker.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/extraTokensCrossChecker.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+
 	"github.com/ElrondNetwork/elrond-go-core/core"
 	"github.com/tidwall/gjson"
 )

--- a/trieTools/zeroBalanceSystemAccountChecker/extraTokensCrossChecker.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/extraTokensCrossChecker.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"errors"
+	"github.com/ElrondNetwork/elrond-go-core/core"
+	"github.com/tidwall/gjson"
+)
+
+const (
+	maxRequestsRetrial = 10
+	multipleSearchBulk = 10000
+)
+
+type nftBalancesGetter interface {
+	getBalance(address, token string) (string, error)
+}
+
+type elasticMultiSearchClient interface {
+	GetMultiple(index string, requests []string) ([]byte, error)
+}
+
+type extraTokensChecker struct {
+	nftBalancesGetter nftBalancesGetter
+	elasticClient     elasticMultiSearchClient
+}
+
+func newExtraTokensCrossChecker(client elasticMultiSearchClient, nftBalancesGetter nftBalancesGetter) (crossTokenChecker, error) {
+	if client == nil {
+		return nil, errors.New("nil elastic client provided")
+	}
+	if nftBalancesGetter == nil {
+		return nil, errors.New("nil nft balances getter provided")
+	}
+
+	return &extraTokensChecker{
+		nftBalancesGetter: nftBalancesGetter,
+		elasticClient:     client,
+	}, nil
+}
+
+func (etc *extraTokensChecker) crossCheckExtraTokens(tokens map[string]struct{}) ([]string, error) {
+	numTokens := len(tokens)
+	log.Info("starting to cross-check", "num of tokens", numTokens)
+
+	bulkSize := core.MinInt(multipleSearchBulk, numTokens)
+	tokensThatStillExist := make([]string, 0)
+	requests := make([]string, 0, bulkSize)
+	currTokenIdx := 0
+	ctRequests := 0
+	for token := range tokens {
+		currTokenIdx++
+		requests = append(requests, createRequest(token))
+
+		notEnoughRequests := len(requests) < bulkSize
+		notLastBulk := currTokenIdx != numTokens
+		if notEnoughRequests && notLastBulk {
+			continue
+		}
+
+		respBytes, err := etc.elasticClient.GetMultiple("accountsesdt", requests)
+		if err != nil {
+			log.Error("elasticClient.GetMultiple(accountsesdt, requests)",
+				"error", err,
+				"requests", requests)
+			return nil, err
+		}
+
+		responses := gjson.Get(string(respBytes), "responses").Array()
+		tokensThatStillExistFromRequest, err := etc.checkIndexerResponse(requests, responses)
+		if err != nil {
+			return nil, err
+		}
+
+		go printProgress(numTokens, currTokenIdx)
+
+		ctRequests += len(requests)
+		requests = make([]string, 0, bulkSize)
+		tokensThatStillExist = append(tokensThatStillExist, tokensThatStillExistFromRequest...)
+	}
+
+	log.Info("finished cross-checking",
+		"total num of tokens", numTokens,
+		"total num of tokens cross-checked", currTokenIdx,
+		"total num of tokens requests in indexer", ctRequests)
+
+	if numTokens != currTokenIdx || numTokens != ctRequests {
+		return nil, errors.New("failed to cross check all tokens, check logs")
+	}
+
+	return tokensThatStillExist, nil
+}
+
+func (etc *extraTokensChecker) checkIndexerResponse(requests []string, responses []gjson.Result) ([]string, error) {
+	tokensThatStillExist := make([]string, 0)
+	for idxRequestedToken, res := range responses {
+		hits := res.Get("hits.hits").Array()
+		if len(hits) != 0 {
+			token := gjson.Get(requests[idxRequestedToken], "query.match.identifier.query").String()
+			log.Debug("found token in indexer with hits/accounts",
+				"token", token,
+				"num hits/accounts", len(hits))
+
+			tokenExists, err := etc.crossCheckToken(hits, token)
+			if err != nil {
+				return nil, err
+			}
+
+			if tokenExists {
+				tokensThatStillExist = append(tokensThatStillExist, token)
+			}
+		}
+		idxRequestedToken++
+	}
+
+	return tokensThatStillExist, nil
+}
+
+func (etc *extraTokensChecker) crossCheckToken(hits []gjson.Result, token string) (bool, error) {
+	tokenExists := false
+	for _, hit := range hits {
+		address := hit.Get("_source.address").String()
+		balance, err := etc.nftBalancesGetter.getBalance(address, token)
+		if err != nil {
+			return false, err
+		}
+
+		log.Debug("checking gateway if token still exists in trie",
+			"token", token,
+			"address", address)
+
+		if balance != "0" {
+			tokenExists = true
+			log.Error("cross-check failed; found token which is still in other address",
+				"token", token,
+				"balance", balance,
+				"address", address)
+			break
+		}
+
+		log.Warn("possible indexer problem",
+			"token", token,
+			"hit in address", address,
+			"found in trie", false)
+	}
+
+	return tokenExists, nil
+}
+
+func createRequest(token string) string {
+	return `{"query" : {"match" : { "identifier": {"query":"` + token + `","operator":"and"}}}}`
+}
+
+func printProgress(numTokens, numTokensCrossChecked int) {
+	log.Info("status",
+		"num cross checked tokens", numTokensCrossChecked,
+		"remaining num of tokens to check", numTokens-numTokensCrossChecked,
+		"progress(%)", (100*numTokensCrossChecked)/numTokens) // this should not panic with div by zero, since func is only called if numTokens > 0
+}

--- a/trieTools/zeroBalanceSystemAccountChecker/extraTokensCrossChecker.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/extraTokensCrossChecker.go
@@ -38,14 +38,14 @@ func (etc *extraTokensChecker) crossCheckExtraTokens(tokens map[string]struct{})
 	bulkSize := core.MinInt(multipleSearchBulk, numTokens)
 	tokensThatStillExist := make([]string, 0)
 	requests := make([]string, 0, bulkSize)
-	currTokenIdx := 0
-	ctRequests := 0
+	currentTokenIdx := 0
+	counterRequests := 0
 	for token := range tokens {
-		currTokenIdx++
+		currentTokenIdx++
 		requests = append(requests, createRequest(token))
 
 		notEnoughRequests := len(requests) < bulkSize
-		notLastBulk := currTokenIdx != numTokens
+		notLastBulk := currentTokenIdx != numTokens
 		if notEnoughRequests && notLastBulk {
 			continue
 		}
@@ -64,19 +64,19 @@ func (etc *extraTokensChecker) crossCheckExtraTokens(tokens map[string]struct{})
 			return nil, err
 		}
 
-		go printProgress(numTokens, currTokenIdx)
+		go printProgress(numTokens, currentTokenIdx)
 
-		ctRequests += len(requests)
+		counterRequests += len(requests)
 		requests = make([]string, 0, bulkSize)
 		tokensThatStillExist = append(tokensThatStillExist, tokensThatStillExistFromRequest...)
 	}
 
 	log.Info("finished cross-checking",
 		"total num of tokens", numTokens,
-		"total num of tokens cross-checked", currTokenIdx,
-		"total num of tokens requests in indexer", ctRequests)
+		"total num of tokens cross-checked", currentTokenIdx,
+		"total num of tokens requests in indexer", counterRequests)
 
-	if numTokens != currTokenIdx || numTokens != ctRequests {
+	if numTokens != currentTokenIdx || numTokens != counterRequests {
 		return nil, errors.New("failed to cross check all tokens, check logs")
 	}
 

--- a/trieTools/zeroBalanceSystemAccountChecker/extraTokensCrossChecker.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/extraTokensCrossChecker.go
@@ -11,7 +11,7 @@ const (
 	multipleSearchBulk = 10000
 )
 
-type nftBalancesGetter interface {
+type tokenBalancesGetter interface {
 	getBalance(address, token string) (string, error)
 }
 
@@ -20,11 +20,11 @@ type elasticMultiSearchClient interface {
 }
 
 type extraTokensChecker struct {
-	nftBalancesGetter nftBalancesGetter
+	nftBalancesGetter tokenBalancesGetter
 	elasticClient     elasticMultiSearchClient
 }
 
-func newExtraTokensCrossChecker(client elasticMultiSearchClient, nftBalancesGetter nftBalancesGetter) (crossTokenChecker, error) {
+func newExtraTokensCrossChecker(client elasticMultiSearchClient, nftBalancesGetter tokenBalancesGetter) (crossTokenChecker, error) {
 	if client == nil {
 		return nil, errors.New("nil elastic client provided")
 	}

--- a/trieTools/zeroBalanceSystemAccountChecker/extraTokensCrossChecker.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/extraTokensCrossChecker.go
@@ -12,14 +12,6 @@ const (
 	multipleSearchBulk = 10000
 )
 
-type tokenBalancesGetter interface {
-	getBalance(address, token string) (string, error)
-}
-
-type elasticMultiSearchClient interface {
-	GetMultiple(index string, requests []string) ([]byte, error)
-}
-
 type extraTokensChecker struct {
 	nftBalancesGetter tokenBalancesGetter
 	elasticClient     elasticMultiSearchClient

--- a/trieTools/zeroBalanceSystemAccountChecker/fileHandler.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/fileHandler.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+)
+
+type osFileHandler struct {
+}
+
+func newOSFileHandler() *osFileHandler {
+	return &osFileHandler{}
+}
+
+func (fh *osFileHandler) Open(name string) (io.Reader, error) {
+	return os.Open(name)
+}
+
+func (fh *osFileHandler) ReadAll(r io.Reader) ([]byte, error) {
+	return ioutil.ReadAll(r)
+}
+
+func (fh *osFileHandler) Getwd() (dir string, err error) {
+	return os.Getwd()
+}
+
+func (fh *osFileHandler) ReadDir(dirname string) ([]FileInfo, error) {
+	files, err := ioutil.ReadDir(dirname)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := make([]FileInfo, 0, len(files))
+	for _, f := range files {
+		ret = append(ret, f)
+	}
+
+	return ret, nil
+}

--- a/trieTools/zeroBalanceSystemAccountChecker/fileHandler.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/fileHandler.go
@@ -4,6 +4,8 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+
+	"github.com/ElrondNetwork/elrond-tools-go/trieTools/zeroBalanceSystemAccountChecker/common"
 )
 
 type osFileHandler struct {
@@ -25,13 +27,13 @@ func (fh *osFileHandler) Getwd() (dir string, err error) {
 	return os.Getwd()
 }
 
-func (fh *osFileHandler) ReadDir(dirname string) ([]FileInfo, error) {
+func (fh *osFileHandler) ReadDir(dirname string) ([]common.FileInfo, error) {
 	files, err := ioutil.ReadDir(dirname)
 	if err != nil {
 		return nil, err
 	}
 
-	ret := make([]FileInfo, 0, len(files))
+	ret := make([]common.FileInfo, 0, len(files))
 	for _, f := range files {
 		ret = append(ret, f)
 	}

--- a/trieTools/zeroBalanceSystemAccountChecker/fileHandler.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/fileHandler.go
@@ -15,18 +15,22 @@ func newOSFileHandler() *osFileHandler {
 	return &osFileHandler{}
 }
 
+// Open opens the named file for reading
 func (fh *osFileHandler) Open(name string) (io.Reader, error) {
 	return os.Open(name)
 }
 
+// ReadAll reads from r until an error or EOF and returns the data it read.
 func (fh *osFileHandler) ReadAll(r io.Reader) ([]byte, error) {
 	return ioutil.ReadAll(r)
 }
 
+// Getwd returns a rooted path name corresponding to the current directory
 func (fh *osFileHandler) Getwd() (dir string, err error) {
 	return os.Getwd()
 }
 
+// ReadDir reads the directory and returns no directory entries along with the error.
 func (fh *osFileHandler) ReadDir(dirname string) ([]common.FileInfo, error) {
 	files, err := ioutil.ReadDir(dirname)
 	if err != nil {

--- a/trieTools/zeroBalanceSystemAccountChecker/flags.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/flags.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"github.com/ElrondNetwork/elrond-tools-go/trieTools/trieToolsCommon"
+	"github.com/ElrondNetwork/elrond-tools-go/trieTools/zeroBalanceSystemAccountChecker/config"
+	"github.com/urfave/cli"
+)
+
+var (
+	tokensDirectory = cli.StringFlag{
+		Name:  "tokens-dir",
+		Usage: "This flag specifies the `directory` where the application will find all exported tokens from all shards. For each file, it expects the input to be a map<address,tokens>",
+		Value: "in",
+	}
+
+	outfile = cli.StringFlag{
+		Name:  "outfile",
+		Usage: "This flag specifies where the output will be stored. It consists of a map<tokens>",
+		Value: "output.json",
+	}
+
+	crossCheck = cli.BoolFlag{
+		Name:  "cross-check",
+		Usage: "This flag specifies if a cross check for zero balances result should be done. If set, checks indexer storage using API calls, so it might take a while.",
+	}
+)
+
+func getFlags() []cli.Flag {
+	return []cli.Flag{
+		trieToolsCommon.LogLevel,
+		trieToolsCommon.DisableAnsiColor,
+		trieToolsCommon.LogSaveFile,
+		trieToolsCommon.LogWithLoggerName,
+		trieToolsCommon.ProfileMode,
+		tokensDirectory,
+		outfile,
+		crossCheck,
+	}
+}
+
+func getFlagsConfig(ctx *cli.Context) config.ContextFlagsZeroBalanceSysAccChecker {
+	flagsConfig := config.ContextFlagsZeroBalanceSysAccChecker{}
+
+	flagsConfig.LogLevel = ctx.GlobalString(trieToolsCommon.LogLevel.Name)
+	flagsConfig.SaveLogFile = ctx.GlobalBool(trieToolsCommon.LogSaveFile.Name)
+	flagsConfig.EnableLogName = ctx.GlobalBool(trieToolsCommon.LogWithLoggerName.Name)
+	flagsConfig.EnablePprof = ctx.GlobalBool(trieToolsCommon.ProfileMode.Name)
+	flagsConfig.TokensDirectory = ctx.GlobalString(tokensDirectory.Name)
+	flagsConfig.Outfile = ctx.GlobalString(outfile.Name)
+	flagsConfig.CrossCheck = ctx.GlobalBool(crossCheck.Name)
+
+	return flagsConfig
+}

--- a/trieTools/zeroBalanceSystemAccountChecker/interface.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/interface.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"io"
+
+	"github.com/ElrondNetwork/elrond-tools-go/trieTools/zeroBalanceSystemAccountChecker/common"
+)
+
+type crossTokenChecker interface {
+	crossCheckExtraTokens(tokens map[string]struct{}) ([]string, error)
+}
+
+type tokenBalancesGetter interface {
+	getBalance(address, token string) (string, error)
+}
+
+type elasticMultiSearchClient interface {
+	GetMultiple(index string, requests []string) ([]byte, error)
+}
+
+type fileHandler interface {
+	Open(name string) (io.Reader, error)
+	ReadAll(r io.Reader) ([]byte, error)
+	Getwd() (dir string, err error)
+	ReadDir(dirname string) ([]common.FileInfo, error)
+}

--- a/trieTools/zeroBalanceSystemAccountChecker/main.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/main.go
@@ -1,0 +1,305 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/ElrondNetwork/elrond-go-core/core/pubkeyConverter"
+	logger "github.com/ElrondNetwork/elrond-go-logger"
+	"github.com/ElrondNetwork/elrond-tools-go/elasticreindexer/config"
+	"github.com/ElrondNetwork/elrond-tools-go/elasticreindexer/elastic"
+	sysAccConfig "github.com/ElrondNetwork/elrond-tools-go/trieTools/zeroBalanceSystemAccountChecker/config"
+	"github.com/pelletier/go-toml"
+	"github.com/urfave/cli"
+
+	"github.com/ElrondNetwork/elrond-tools-go/trieTools/trieToolsCommon"
+	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
+	"io/fs"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	logFilePrefix   = "system-account-zero-tokens-balance-checker"
+	addressLength   = 32
+	outputFilePerms = 0644
+	tomlFile        = "./config.toml"
+)
+
+type crossTokenChecker interface {
+	crossCheckExtraTokens(tokens map[string]struct{}) ([]string, error)
+}
+
+func main() {
+	app := cli.NewApp()
+	app.Name = "Tokens exporter CLI app"
+	app.Usage = "This is the entry point for the tool that checks which tokens are not used anymore(only stored in system account)"
+	app.Flags = getFlags()
+	app.Authors = []cli.Author{
+		{
+			Name:  "The Elrond Team",
+			Email: "contact@elrond.com",
+		},
+	}
+
+	app.Action = func(c *cli.Context) error {
+		return startProcess(c)
+	}
+
+	err := app.Run(os.Args)
+	if err != nil {
+		log.Error(err.Error())
+		os.Exit(1)
+		return
+	}
+}
+
+func startProcess(c *cli.Context) error {
+	flagsConfig := getFlagsConfig(c)
+
+	_, errLogger := trieToolsCommon.AttachFileLogger(log, logFilePrefix, flagsConfig.ContextFlagsConfig)
+	if errLogger != nil {
+		return errLogger
+	}
+
+	log.Info("sanity checks...")
+
+	err := logger.SetLogLevel(flagsConfig.LogLevel)
+	if err != nil {
+		return err
+	}
+
+	log.Info("starting processing trie", "pid", os.Getpid())
+
+	addressTokensMap, err := readInputs(flagsConfig.TokensDirectory)
+	if err != nil {
+		return err
+	}
+
+	extraTokens, err := exportSystemAccZeroTokensBalances(addressTokensMap)
+	if err != nil {
+		return err
+	}
+
+	if flagsConfig.CrossCheck {
+		err = crossCheckExtraTokens(extraTokens)
+		if err != nil {
+			return err
+		}
+	}
+
+	err = saveResult(extraTokens, flagsConfig.Outfile)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func readInputs(tokensDir string) (map[string]map[string]struct{}, error) {
+	workingDir, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+
+	fullPath := filepath.Join(workingDir, tokensDir)
+	contents, err := ioutil.ReadDir(fullPath)
+	if err != nil {
+		return nil, err
+	}
+
+	allAddressesTokensMap := make(map[string]map[string]struct{})
+	for _, file := range contents {
+		if file.IsDir() {
+			continue
+		}
+
+		addressTokensMapInCurrFile, err := getFileContent(filepath.Join(fullPath, file.Name()))
+		if err != nil {
+			return nil, err
+		}
+
+		merge(allAddressesTokensMap, addressTokensMapInCurrFile)
+		log.Info("read data from",
+			"file", file.Name(),
+			"num addresses in current file", len(addressTokensMapInCurrFile),
+			"num addresses in total, after merge", len(allAddressesTokensMap))
+	}
+
+	return allAddressesTokensMap, nil
+}
+
+func getFileContent(file string) (map[string]map[string]struct{}, error) {
+	jsonFile, err := os.Open(file)
+	if err != nil {
+		return nil, err
+	}
+
+	bytesFromJson, err := ioutil.ReadAll(jsonFile)
+	if err != nil {
+		return nil, err
+	}
+
+	addressTokensMapInCurrFile := make(map[string]map[string]struct{})
+	err = json.Unmarshal(bytesFromJson, &addressTokensMapInCurrFile)
+	if err != nil {
+		return nil, err
+	}
+
+	return addressTokensMapInCurrFile, nil
+}
+
+func merge(dest, src map[string]map[string]struct{}) {
+	for addressSrc, tokensSrc := range src {
+		_, existsInDest := dest[addressSrc]
+		if !existsInDest {
+			dest[addressSrc] = tokensSrc
+		} else {
+			log.Debug("same address found in multiple files", "address", addressSrc)
+			addTokensInDestAddress(tokensSrc, dest, addressSrc)
+		}
+	}
+}
+
+func addTokensInDestAddress(tokens map[string]struct{}, dest map[string]map[string]struct{}, address string) {
+	for token := range tokens {
+		dest[address][token] = struct{}{}
+	}
+}
+
+func exportSystemAccZeroTokensBalances(allAddressesTokensMap map[string]map[string]struct{}) (map[string]struct{}, error) {
+	addressConverter, err := pubkeyConverter.NewBech32PubkeyConverter(addressLength, log)
+	if err != nil {
+		return nil, err
+	}
+
+	systemSCAddress := addressConverter.Encode(vmcommon.SystemAccountAddress)
+	allTokensInSystemSCAddress, foundSystemSCAddress := allAddressesTokensMap[systemSCAddress]
+	if !foundSystemSCAddress {
+		return nil, fmt.Errorf("no system account address(%s) found", systemSCAddress)
+	}
+
+	allTokens := getAllTokensWithoutSystemAccount(allAddressesTokensMap, systemSCAddress)
+	log.Info("found",
+		"total num of tokens in all addresses", len(allTokens),
+		"total num of tokens in system sc address", len(allTokensInSystemSCAddress))
+
+	return getExtraTokens(allTokens, allTokensInSystemSCAddress), nil
+}
+
+func getAllTokensWithoutSystemAccount(allAddressesTokensMap map[string]map[string]struct{}, systemSCAddress string) map[string]struct{} {
+	delete(allAddressesTokensMap, systemSCAddress)
+
+	allTokens := make(map[string]struct{})
+	for _, tokens := range allAddressesTokensMap {
+		for token := range tokens {
+			allTokens[token] = struct{}{}
+		}
+	}
+
+	return allTokens
+}
+
+func getExtraTokens(allTokens, allTokensInSystemSCAddress map[string]struct{}) map[string]struct{} {
+	ctTokensOnlyInSystemAcc := 0
+	extraTokens := make(map[string]struct{})
+	for tokenInSystemSC := range allTokensInSystemSCAddress {
+		_, exists := allTokens[tokenInSystemSC]
+		if !exists {
+			ctTokensOnlyInSystemAcc++
+			addTokenInMapIfHasNonce(tokenInSystemSC, extraTokens)
+		}
+	}
+
+	log.Info("found",
+		"num tokens in system account, but not in any other address", ctTokensOnlyInSystemAcc,
+		"num of sfts/nfts/metaesdts metadata only found in system sc address", len(extraTokens))
+
+	return extraTokens
+}
+
+func addTokenInMapIfHasNonce(token string, tokens map[string]struct{}) {
+	if hasNonce(token) {
+		tokens[token] = struct{}{}
+	}
+}
+
+func hasNonce(token string) bool {
+	return strings.Count(token, "-") == 2
+}
+
+func saveResult(tokens map[string]struct{}, outfile string) error {
+	jsonBytes, err := json.MarshalIndent(tokens, "", " ")
+	if err != nil {
+		return err
+	}
+
+	log.Info("writing result in", "file", outfile)
+	err = ioutil.WriteFile(outfile, jsonBytes, fs.FileMode(outputFilePerms))
+	if err != nil {
+		return err
+	}
+
+	log.Info("finished exporting zero balance tokens map")
+	return nil
+}
+
+func crossCheckExtraTokens(extraTokens map[string]struct{}) error {
+	cfg, err := loadConfig()
+	if err != nil {
+		return err
+	}
+
+	nftGetter := newNFTBalanceGetter(cfg.Config.Gateway.URL)
+	elasticClient, err := elastic.NewElasticClient(config.ElasticInstanceConfig{
+		URL:      cfg.Config.ElasticIndexerConfig.URL,
+		Username: cfg.Config.ElasticIndexerConfig.Username,
+		Password: cfg.Config.ElasticIndexerConfig.Password,
+	})
+	if err != nil {
+		return err
+	}
+
+	tokensChecker, err := newExtraTokensCrossChecker(elasticClient, nftGetter)
+	if err != nil {
+		return err
+	}
+
+	tokensThatStillExist, err := tokensChecker.crossCheckExtraTokens(extraTokens)
+	if err != nil {
+		return err
+	}
+
+	removeTokensThatStillExist(tokensThatStillExist, extraTokens)
+	return nil
+}
+
+func loadConfig() (*sysAccConfig.GeneralConfig, error) {
+	tomlBytes, err := ioutil.ReadFile(tomlFile)
+	if err != nil {
+		return nil, err
+	}
+
+	var tc sysAccConfig.GeneralConfig
+	err = toml.Unmarshal(tomlBytes, &tc)
+	if err != nil {
+		return nil, err
+	}
+
+	return &tc, nil
+}
+
+func removeTokensThatStillExist(tokensThatStillExist []string, tokens map[string]struct{}) {
+	if len(tokensThatStillExist) == 0 {
+		log.Info("all cross-checks were successful; exported tokens are only stored in system account")
+		return
+	}
+
+	log.Error("found tokens with balances that still exist in other accounts; probably found in pending mbs during snapshot; will remove them from exported tokens",
+		"tokens", tokensThatStillExist)
+
+	for _, token := range tokensThatStillExist {
+		delete(tokens, token)
+	}
+}

--- a/trieTools/zeroBalanceSystemAccountChecker/main.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/main.go
@@ -2,18 +2,19 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"github.com/ElrondNetwork/elrond-go-core/core/pubkeyConverter"
 	logger "github.com/ElrondNetwork/elrond-go-logger"
 	"github.com/ElrondNetwork/elrond-tools-go/elasticreindexer/config"
 	"github.com/ElrondNetwork/elrond-tools-go/elasticreindexer/elastic"
 	sysAccConfig "github.com/ElrondNetwork/elrond-tools-go/trieTools/zeroBalanceSystemAccountChecker/config"
+	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
 	"github.com/pelletier/go-toml"
 	"github.com/urfave/cli"
 	"strconv"
 
 	"github.com/ElrondNetwork/elrond-tools-go/trieTools/trieToolsCommon"
-	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
 	"io/fs"
 	"io/ioutil"
 	"os"
@@ -73,24 +74,24 @@ func startProcess(c *cli.Context) error {
 
 	log.Info("starting processing trie", "pid", os.Getpid())
 
-	shardAddressTokensMap, err := readInputs(flagsConfig.TokensDirectory)
+	globalAddressTokensMap, shardAddressTokensMap, err := readInputs(flagsConfig.TokensDirectory)
 	if err != nil {
 		return err
 	}
 
-	extraTokens, err := exportSystemAccZeroTokensBalances(shardAddressTokensMap)
+	globalExtraTokens, extraTokensPerShard, err := exportSystemAccZeroTokensBalances(globalAddressTokensMap, shardAddressTokensMap)
 	if err != nil {
 		return err
 	}
 
 	if flagsConfig.CrossCheck {
-		err = crossCheckExtraTokens(extraTokens)
+		err = crossCheckExtraTokens(globalExtraTokens, extraTokensPerShard)
 		if err != nil {
 			return err
 		}
 	}
 
-	err = saveResult(extraTokens, flagsConfig.Outfile)
+	err = saveResult(extraTokensPerShard, flagsConfig.Outfile)
 	if err != nil {
 		return err
 	}
@@ -98,20 +99,20 @@ func startProcess(c *cli.Context) error {
 	return nil
 }
 
-func readInputs(tokensDir string) (map[uint32]map[string]map[string]struct{}, error) {
+func readInputs(tokensDir string) (map[string]map[string]struct{}, map[uint32]map[string]map[string]struct{}, error) {
 	workingDir, err := os.Getwd()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	fullPath := filepath.Join(workingDir, tokensDir)
 	contents, err := ioutil.ReadDir(fullPath)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
+	globalAddressTokensMap := make(map[string]map[string]struct{})
 	shardAddressTokensMap := make(map[uint32]map[string]map[string]struct{})
-	totalNumAddresses := 0
 	for _, file := range contents {
 		if file.IsDir() {
 			continue
@@ -119,26 +120,32 @@ func readInputs(tokensDir string) (map[uint32]map[string]map[string]struct{}, er
 
 		shardID, err := getShardID(file.Name())
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		addressTokensMapInCurrFile, err := getFileContent(filepath.Join(fullPath, file.Name()))
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
-		shardAddressTokensMap[shardID] = addressTokensMapInCurrFile
+		shardAddressTokensMap[shardID] = copyMap(addressTokensMapInCurrFile)
+		merge(globalAddressTokensMap, addressTokensMapInCurrFile)
+		numTokensInShard := 0
+		for _, tokens := range shardAddressTokensMap[shardID] {
+			for range tokens {
+				numTokensInShard++
+			}
+		}
 
-		numAddressesInShard := len(addressTokensMapInCurrFile)
-		totalNumAddresses += numAddressesInShard
 		log.Info("read data from",
 			"file", file.Name(),
-			"num addresses in current file", numAddressesInShard,
 			"shard", shardID,
-			"total num addresses in all shards", totalNumAddresses)
+			"num tokens in shard", numTokensInShard,
+			"num addresses in current file", len(shardAddressTokensMap[shardID]),
+			"total num addresses in all shards", len(globalAddressTokensMap))
 	}
 
-	return shardAddressTokensMap, nil
+	return globalAddressTokensMap, shardAddressTokensMap, nil
 }
 
 func getShardID(file string) (uint32, error) {
@@ -150,6 +157,37 @@ func getShardID(file string) (uint32, error) {
 	}
 
 	return uint32(shardID), nil
+}
+
+func merge(dest, src map[string]map[string]struct{}) {
+	for addressSrc, tokensSrc := range src {
+		_, existsInDest := dest[addressSrc]
+		if !existsInDest {
+			dest[addressSrc] = tokensSrc
+		} else {
+			log.Debug("same address found in multiple files", "address", addressSrc)
+			addTokensInDestAddress(tokensSrc, dest, addressSrc)
+		}
+	}
+}
+
+func copyMap(addressTokensMap map[string]map[string]struct{}) map[string]map[string]struct{} {
+	addressTokensMapCopy := make(map[string]map[string]struct{})
+
+	for address, tokens := range addressTokensMap {
+		addressTokensMapCopy[address] = make(map[string]struct{})
+		for token := range tokens {
+			addressTokensMapCopy[address][token] = struct{}{}
+		}
+	}
+
+	return addressTokensMapCopy
+}
+
+func addTokensInDestAddress(tokens map[string]struct{}, dest map[string]map[string]struct{}, address string) {
+	for token := range tokens {
+		dest[address][token] = struct{}{}
+	}
 }
 
 func getFileContent(file string) (map[string]map[string]struct{}, error) {
@@ -172,33 +210,95 @@ func getFileContent(file string) (map[string]map[string]struct{}, error) {
 	return addressTokensMapInCurrFile, nil
 }
 
-func exportSystemAccZeroTokensBalances(shardAddressTokenMap map[uint32]map[string]map[string]struct{}) (map[uint32]map[string]struct{}, error) {
+func getGlobalExtraTokens(allAddressesTokensMap map[string]map[string]struct{}, systemSCAddress string) (map[string]struct{}, error) {
+	allTokensInSystemSCAddress, foundSystemSCAddress := allAddressesTokensMap[systemSCAddress]
+	if !foundSystemSCAddress {
+		return nil, fmt.Errorf("no system account address(%s) found", systemSCAddress)
+	}
+
+	allTokens := getAllTokensWithoutSystemAccount(allAddressesTokensMap, systemSCAddress)
+	log.Info("found",
+		"global num of tokens in all addresses", len(allTokens),
+		"global num of tokens in system sc address", len(allTokensInSystemSCAddress))
+
+	return getExtraTokens(allTokens, allTokensInSystemSCAddress), nil
+}
+
+func exportSystemAccZeroTokensBalances(globalAddressTokensMap map[string]map[string]struct{}, shardAddressTokenMap map[uint32]map[string]map[string]struct{}) (map[string]struct{}, map[uint32]map[string]struct{}, error) {
 	addressConverter, err := pubkeyConverter.NewBech32PubkeyConverter(addressLength, log)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
+
+	systemSCAddress := addressConverter.Encode(vmcommon.SystemAccountAddress)
+	globalExtraTokens, err := getGlobalExtraTokens(globalAddressTokensMap, systemSCAddress)
+	if err != nil {
+		return nil, nil, err
+	}
+	log.Info("found", "global num of extra tokens", len(globalExtraTokens))
 
 	ret := make(map[uint32]map[string]struct{})
-	systemSCAddress := addressConverter.Encode(vmcommon.SystemAccountAddress)
 	for shardID, addressTokensMap := range shardAddressTokenMap {
-		tokensInSystemAccAddress, found := addressTokensMap[systemSCAddress]
+		shardTokensInSystemAccAddress, found := addressTokensMap[systemSCAddress]
 		if !found {
-			return nil, fmt.Errorf("no system account address(%s) found in shard = %v", systemSCAddress, shardID)
+			return nil, nil, fmt.Errorf("no system account address(%s) found in shard = %v", systemSCAddress, shardID)
 		}
 
-		allTokensWithoutSysAccount := getAllTokensWithoutSystemAccount(addressTokensMap, systemSCAddress)
-		extraTokens := getExtraTokens(allTokensWithoutSysAccount, tokensInSystemAccAddress)
-		ret[shardID] = extraTokens
+		extraTokensInShard := intersection(globalExtraTokens, shardTokensInSystemAccAddress)
+		log.Info("found", "shard", shardID, "num tokens in system account", len(shardTokensInSystemAccAddress), "num extra tokens", len(extraTokensInShard))
+		ret[shardID] = extraTokensInShard
+	}
+	if !sanityCheckExtraTokens(ret, globalExtraTokens) {
+		return nil, nil, errors.New("sanity check for exported tokens failed")
 	}
 
-	return ret, nil
+	return globalExtraTokens, ret, nil
+}
+
+func sanityCheckExtraTokens(shardExtraTokensMap map[uint32]map[string]struct{}, globalExtraTokens map[string]struct{}) bool {
+	allMergedExtraTokens := make(map[string]struct{})
+	for _, extraTokensInShard := range shardExtraTokensMap {
+		for extraToken := range extraTokensInShard {
+			allMergedExtraTokens[extraToken] = struct{}{}
+		}
+	}
+
+	return checkSameMap(allMergedExtraTokens, globalExtraTokens)
+}
+
+func checkSameMap(map1, map2 map[string]struct{}) bool {
+	if len(map1) != len(map2) {
+		return false
+	}
+
+	for elemInMap1 := range map1 {
+		_, foundInMap2 := map2[elemInMap1]
+		if !foundInMap2 {
+			return false
+		}
+	}
+
+	return true
+}
+
+func intersection(allTokens, tokens map[string]struct{}) map[string]struct{} {
+	ret := make(map[string]struct{})
+	for token := range tokens {
+		_, found := allTokens[token]
+		if found {
+			ret[token] = struct{}{}
+		}
+	}
+
+	return ret
 }
 
 func getAllTokensWithoutSystemAccount(allAddressesTokensMap map[string]map[string]struct{}, systemSCAddress string) map[string]struct{} {
-	delete(allAddressesTokensMap, systemSCAddress)
+	allAddressTokensMapCopy := copyMap(allAddressesTokensMap)
+	delete(allAddressTokensMapCopy, systemSCAddress)
 
 	allTokens := make(map[string]struct{})
-	for _, tokens := range allAddressesTokensMap {
+	for _, tokens := range allAddressTokensMapCopy {
 		for token := range tokens {
 			allTokens[token] = struct{}{}
 		}
@@ -251,7 +351,7 @@ func saveResult(tokens map[uint32]map[string]struct{}, outfile string) error {
 	return nil
 }
 
-func crossCheckExtraTokens(extraTokens map[uint32]map[string]struct{}) error {
+func crossCheckExtraTokens(globalExtraTokens map[string]struct{}, extraTokensPerShard map[uint32]map[string]struct{}) error {
 	cfg, err := loadConfig()
 	if err != nil {
 		return err
@@ -272,13 +372,12 @@ func crossCheckExtraTokens(extraTokens map[uint32]map[string]struct{}) error {
 		return err
 	}
 
-	for shardID, extraTokensInShard := range extraTokens {
-		log.Info("cross checking extra tokens", "shardID", shardID, "num of tokens", len(extraTokensInShard))
-		tokensThatStillExist, err := tokensChecker.crossCheckExtraTokens(extraTokensInShard)
-		if err != nil {
-			return err
-		}
+	tokensThatStillExist, err := tokensChecker.crossCheckExtraTokens(globalExtraTokens)
+	if err != nil {
+		return err
+	}
 
+	for _, extraTokensInShard := range extraTokensPerShard {
 		removeTokensThatStillExist(tokensThatStillExist, extraTokensInShard)
 	}
 

--- a/trieTools/zeroBalanceSystemAccountChecker/main.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/main.go
@@ -134,8 +134,8 @@ func readInputs(tokensDir string) (map[string]map[string]struct{}, map[uint32]ma
 		log.Info("read data from",
 			"file", file.Name(),
 			"shard", shardID,
-			"num tokens in shard", getNumTokens(shardAddressTokensMap[shardID]),
-			"num addresses in current file", len(shardAddressTokensMap[shardID]),
+			"num tokens in shard", trieToolsCommon.GetNumTokens(shardAddressTokensMap[shardID]),
+			"num addresses in shard", len(shardAddressTokensMap[shardID]),
 			"total num addresses in all shards", len(globalAddressTokensMap))
 	}
 
@@ -202,17 +202,6 @@ func copyMap(addressTokensMap map[string]map[string]struct{}) map[string]map[str
 	}
 
 	return addressTokensMapCopy
-}
-
-func getNumTokens(addressTokensMap map[string]map[string]struct{}) int {
-	numTokensInShard := 0
-	for _, tokens := range addressTokensMap {
-		for range tokens {
-			numTokensInShard++
-		}
-	}
-
-	return numTokensInShard
 }
 
 func merge(dest, src map[string]map[string]struct{}) {

--- a/trieTools/zeroBalanceSystemAccountChecker/main.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/main.go
@@ -4,22 +4,22 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/ElrondNetwork/elrond-go-core/core/pubkeyConverter"
-	logger "github.com/ElrondNetwork/elrond-go-logger"
-	"github.com/ElrondNetwork/elrond-tools-go/elasticreindexer/config"
-	"github.com/ElrondNetwork/elrond-tools-go/elasticreindexer/elastic"
-	sysAccConfig "github.com/ElrondNetwork/elrond-tools-go/trieTools/zeroBalanceSystemAccountChecker/config"
-	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
-	"github.com/pelletier/go-toml"
-	"github.com/urfave/cli"
-	"strconv"
-
-	"github.com/ElrondNetwork/elrond-tools-go/trieTools/trieToolsCommon"
 	"io/fs"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
+
+	"github.com/ElrondNetwork/elrond-go-core/core/pubkeyConverter"
+	logger "github.com/ElrondNetwork/elrond-go-logger"
+	"github.com/ElrondNetwork/elrond-tools-go/elasticreindexer/config"
+	"github.com/ElrondNetwork/elrond-tools-go/elasticreindexer/elastic"
+	"github.com/ElrondNetwork/elrond-tools-go/trieTools/trieToolsCommon"
+	sysAccConfig "github.com/ElrondNetwork/elrond-tools-go/trieTools/zeroBalanceSystemAccountChecker/config"
+	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
+	"github.com/pelletier/go-toml"
+	"github.com/urfave/cli"
 )
 
 const (
@@ -65,14 +65,10 @@ func startProcess(c *cli.Context) error {
 		return errLogger
 	}
 
-	log.Info("sanity checks...")
-
 	err := logger.SetLogLevel(flagsConfig.LogLevel)
 	if err != nil {
 		return err
 	}
-
-	log.Info("starting processing trie", "pid", os.Getpid())
 
 	globalAddressTokensMap, shardAddressTokensMap, err := readInputs(flagsConfig.TokensDirectory)
 	if err != nil {
@@ -357,7 +353,7 @@ func crossCheckExtraTokens(globalExtraTokens map[string]struct{}, extraTokensPer
 		return err
 	}
 
-	nftGetter := newNFTBalanceGetter(cfg.Config.Gateway.URL)
+	nftGetter := newTokenBalanceGetter(cfg.Config.Gateway.URL)
 	elasticClient, err := elastic.NewElasticClient(config.ElasticInstanceConfig{
 		URL:      cfg.Config.ElasticIndexerConfig.URL,
 		Username: cfg.Config.ElasticIndexerConfig.Username,

--- a/trieTools/zeroBalanceSystemAccountChecker/mocks/fileHandlerStub.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/mocks/fileHandlerStub.go
@@ -1,0 +1,51 @@
+package mocks
+
+import (
+	"io"
+
+	"github.com/ElrondNetwork/elrond-tools-go/trieTools/zeroBalanceSystemAccountChecker/common"
+)
+
+// FileHandlerStub -
+type FileHandlerStub struct {
+	OpenCalled    func(name string) (io.Reader, error)
+	ReadAllCalled func(r io.Reader) ([]byte, error)
+	GetwdCalled   func() (dir string, err error)
+	ReadDirCalled func(dirname string) ([]common.FileInfo, error)
+}
+
+// Open -
+func (fhs *FileHandlerStub) Open(name string) (io.Reader, error) {
+	if fhs.OpenCalled != nil {
+		return fhs.OpenCalled(name)
+	}
+
+	return nil, nil
+}
+
+// ReadAll -
+func (fhs *FileHandlerStub) ReadAll(r io.Reader) ([]byte, error) {
+	if fhs.ReadAllCalled != nil {
+		return fhs.ReadAllCalled(r)
+	}
+
+	return nil, nil
+}
+
+// Getwd -
+func (fhs *FileHandlerStub) Getwd() (dir string, err error) {
+	if fhs.GetwdCalled != nil {
+		return fhs.GetwdCalled()
+	}
+
+	return "", nil
+}
+
+// ReadDir -
+func (fhs *FileHandlerStub) ReadDir(dirname string) ([]common.FileInfo, error) {
+	if fhs.ReadDirCalled != nil {
+		return fhs.ReadDirCalled(dirname)
+	}
+
+	return nil, nil
+}

--- a/trieTools/zeroBalanceSystemAccountChecker/mocks/fileStub.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/mocks/fileStub.go
@@ -1,0 +1,25 @@
+package mocks
+
+// FileStub -
+type FileStub struct {
+	NameCalled  func() string
+	IsDirCalled func() bool
+}
+
+// Name -
+func (fs *FileStub) Name() string {
+	if fs.NameCalled != nil {
+		return fs.NameCalled()
+	}
+
+	return ""
+}
+
+// IsDir -
+func (fs *FileStub) IsDir() bool {
+	if fs.IsDirCalled != nil {
+		return fs.IsDirCalled()
+	}
+
+	return false
+}

--- a/trieTools/zeroBalanceSystemAccountChecker/nftBalanceGetter.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/nftBalanceGetter.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"fmt"
+	"github.com/tidwall/gjson"
+	"io"
+	"math/big"
+	"net/http"
+	"strings"
+)
+
+type nftBalanceGetter struct {
+	proxyURL string
+}
+
+func newNFTBalanceGetter(proxyURL string) *nftBalanceGetter {
+	return &nftBalanceGetter{
+		proxyURL: proxyURL,
+	}
+}
+
+func (eg *nftBalanceGetter) getBalance(address, token string) (string, error) {
+	tokenID, nonce := getTokenIDAndNonce(token)
+	return eg.fetchNFTBalanceWithRetrial(address, tokenID, nonce)
+}
+
+func getTokenIDAndNonce(token string) (string, uint64) {
+	tokens := strings.Split(token, "-")
+	tokenID := tokens[0] + "-" + tokens[1]
+
+	nonce := big.NewInt(0)
+	nonce.SetString(tokens[2], 16)
+
+	return tokenID, nonce.Uint64()
+}
+
+func (eg *nftBalanceGetter) fetchNFTBalanceWithRetrial(address, tokenID string, nonce uint64) (string, error) {
+	ctRetrials := 0
+
+	for ctRetrials < maxRequestsRetrial {
+		url := fmt.Sprintf("%s/address/%s/nft/%s/nonce/%d", eg.proxyURL, address, tokenID, nonce)
+		resp, errHttp := http.Get(url)
+		body, errBody := eg.getBody(resp)
+		if errHttp == nil && errBody == nil {
+			return gjson.Get(body, "data.tokenData.balance").String(), nil
+		}
+
+		log.Warn("could not get balance; retrying...",
+			"address", address,
+			"tokenID", tokenID,
+			"token nonce", nonce,
+			"error http", errHttp,
+			"error body", errBody,
+			"num retrials", ctRetrials)
+
+		ctRetrials++
+	}
+
+	return "", fmt.Errorf("could not get adress's tokens = %s after num of retrials = %d", address, maxRequestsRetrial)
+}
+
+func (eg *nftBalanceGetter) getBody(response *http.Response) (string, error) {
+	bodyBytes, err := io.ReadAll(response.Body)
+	if err != nil {
+		return "", fmt.Errorf("could not ready bytes from body; error: %w", err)
+	}
+
+	bodyStr := string(bodyBytes)
+	bodyErr := gjson.Get(bodyStr, "error").String()
+	if len(bodyErr) != 0 {
+		return "", fmt.Errorf("got error in body response when getting esdt tokens, proxy url: %s, body error: %s", eg.proxyURL, bodyErr)
+	}
+
+	return string(bodyBytes), nil
+}

--- a/trieTools/zeroBalanceSystemAccountChecker/tokenBalanceGetter.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/tokenBalanceGetter.go
@@ -2,26 +2,27 @@ package main
 
 import (
 	"fmt"
-	"github.com/tidwall/gjson"
 	"io"
 	"math/big"
 	"net/http"
 	"strings"
+
+	"github.com/tidwall/gjson"
 )
 
-type nftBalanceGetter struct {
+type tokenBalanceGetter struct {
 	proxyURL string
 }
 
-func newNFTBalanceGetter(proxyURL string) *nftBalanceGetter {
-	return &nftBalanceGetter{
+func newTokenBalanceGetter(proxyURL string) *tokenBalanceGetter {
+	return &tokenBalanceGetter{
 		proxyURL: proxyURL,
 	}
 }
 
-func (eg *nftBalanceGetter) getBalance(address, token string) (string, error) {
+func (tbg *tokenBalanceGetter) getBalance(address, token string) (string, error) {
 	tokenID, nonce := getTokenIDAndNonce(token)
-	return eg.fetchNFTBalanceWithRetrial(address, tokenID, nonce)
+	return tbg.fetchTokenBalanceWithRetrial(address, tokenID, nonce)
 }
 
 func getTokenIDAndNonce(token string) (string, uint64) {
@@ -34,13 +35,13 @@ func getTokenIDAndNonce(token string) (string, uint64) {
 	return tokenID, nonce.Uint64()
 }
 
-func (eg *nftBalanceGetter) fetchNFTBalanceWithRetrial(address, tokenID string, nonce uint64) (string, error) {
+func (tbg *tokenBalanceGetter) fetchTokenBalanceWithRetrial(address, tokenID string, nonce uint64) (string, error) {
 	ctRetrials := 0
 
 	for ctRetrials < maxRequestsRetrial {
-		url := fmt.Sprintf("%s/address/%s/nft/%s/nonce/%d", eg.proxyURL, address, tokenID, nonce)
+		url := fmt.Sprintf("%s/address/%s/nft/%s/nonce/%d", tbg.proxyURL, address, tokenID, nonce)
 		resp, errHttp := http.Get(url)
-		body, errBody := eg.getBody(resp)
+		body, errBody := tbg.getBody(resp)
 		if errHttp == nil && errBody == nil {
 			return gjson.Get(body, "data.tokenData.balance").String(), nil
 		}
@@ -59,7 +60,7 @@ func (eg *nftBalanceGetter) fetchNFTBalanceWithRetrial(address, tokenID string, 
 	return "", fmt.Errorf("could not get adress's tokens = %s after num of retrials = %d", address, maxRequestsRetrial)
 }
 
-func (eg *nftBalanceGetter) getBody(response *http.Response) (string, error) {
+func (tbg *tokenBalanceGetter) getBody(response *http.Response) (string, error) {
 	bodyBytes, err := io.ReadAll(response.Body)
 	if err != nil {
 		return "", fmt.Errorf("could not ready bytes from body; error: %w", err)
@@ -68,7 +69,7 @@ func (eg *nftBalanceGetter) getBody(response *http.Response) (string, error) {
 	bodyStr := string(bodyBytes)
 	bodyErr := gjson.Get(bodyStr, "error").String()
 	if len(bodyErr) != 0 {
-		return "", fmt.Errorf("got error in body response when getting esdt tokens, proxy url: %s, body error: %s", eg.proxyURL, bodyErr)
+		return "", fmt.Errorf("got error in body response when getting esdt tokens, proxy url: %s, body error: %s", tbg.proxyURL, bodyErr)
 	}
 
 	return string(bodyBytes), nil

--- a/trieTools/zeroBalanceSystemAccountChecker/tokensInputReader.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/tokensInputReader.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/ElrondNetwork/elrond-tools-go/trieTools/trieToolsCommon"
+)
+
+type FileInfo interface {
+	Name() string
+	IsDir() bool
+}
+
+type fileHandler interface {
+	Open(name string) (io.Reader, error)
+	ReadAll(r io.Reader) ([]byte, error)
+	Getwd() (dir string, err error)
+	ReadDir(dirname string) ([]FileInfo, error)
+}
+
+type addressTokensMapFileReader struct {
+	fileHandler fileHandler
+}
+
+func newAddressTokensMapFileReader(
+	fileHandler fileHandler,
+) *addressTokensMapFileReader {
+	return &addressTokensMapFileReader{
+		fileHandler: fileHandler,
+	}
+}
+
+func (atr *addressTokensMapFileReader) readInputs(tokensDir string) (trieToolsCommon.AddressTokensMap, map[uint32]trieToolsCommon.AddressTokensMap, error) {
+	workingDir, err := atr.fileHandler.Getwd()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	fullPath := filepath.Join(workingDir, tokensDir)
+	contents, err := atr.fileHandler.ReadDir(fullPath)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	globalAddressTokensMap := trieToolsCommon.NewAddressTokensMap()
+	shardAddressTokensMap := make(map[uint32]trieToolsCommon.AddressTokensMap)
+	for _, file := range contents {
+		if file.IsDir() {
+			continue
+		}
+
+		shardID, err := getShardID(file.Name())
+		if err != nil {
+			return nil, nil, err
+		}
+
+		addressTokensMapInCurrFile, err := atr.getFileContent(filepath.Join(fullPath, file.Name()))
+		if err != nil {
+			return nil, nil, err
+		}
+
+		shardAddressTokensMap[shardID] = addressTokensMapInCurrFile.ShallowClone()
+		merge(globalAddressTokensMap, addressTokensMapInCurrFile)
+
+		log.Info("read data from",
+			"file", file.Name(),
+			"shard", shardID,
+			"num tokens in shard", shardAddressTokensMap[shardID].NumTokens(),
+			"num addresses in shard", shardAddressTokensMap[shardID].NumAddresses(),
+			"total num addresses in all shards", globalAddressTokensMap.NumAddresses())
+	}
+
+	return globalAddressTokensMap, shardAddressTokensMap, nil
+}
+
+func getShardID(file string) (uint32, error) {
+	shardIDStr := strings.TrimPrefix(file, "shard")
+	shardIDStr = strings.TrimSuffix(shardIDStr, ".json")
+	shardID, err := strconv.Atoi(shardIDStr)
+	if err != nil {
+		return 0, fmt.Errorf("invalid file input name; expected tokens shard file name to be <shardX.json>, where X = number(e.g. shard0.json)")
+	}
+
+	return uint32(shardID), nil
+}
+
+func (atr *addressTokensMapFileReader) getFileContent(file string) (trieToolsCommon.AddressTokensMap, error) {
+	jsonFile, err := atr.fileHandler.Open(file)
+	if err != nil {
+		return nil, err
+	}
+
+	bytesFromJson, err := atr.fileHandler.ReadAll(jsonFile)
+	if err != nil {
+		return nil, err
+	}
+
+	addressTokensMapInCurrFile := make(map[string]map[string]struct{})
+	err = json.Unmarshal(bytesFromJson, &addressTokensMapInCurrFile)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := trieToolsCommon.NewAddressTokensMap()
+	for address, tokens := range addressTokensMapInCurrFile {
+		tokensWithNonce := getTokensWithNonce(tokens)
+		ret.Add(address, tokensWithNonce)
+	}
+
+	return ret, nil
+}
+
+func getTokensWithNonce(tokens map[string]struct{}) map[string]struct{} {
+	ret := make(map[string]struct{})
+
+	for token := range tokens {
+		addTokenInMapIfHasNonce(token, ret)
+	}
+
+	return ret
+}
+
+func addTokenInMapIfHasNonce(token string, tokens map[string]struct{}) {
+	if hasNonce(token) {
+		tokens[token] = struct{}{}
+	}
+}
+
+func hasNonce(token string) bool {
+	return strings.Count(token, "-") == 2
+}
+
+func merge(dest, src trieToolsCommon.AddressTokensMap) {
+	for addressSrc, tokensSrc := range src.GetMapCopy() {
+		if dest.HasAddress(addressSrc) {
+			log.Debug("same address found in multiple files", "address", addressSrc)
+		}
+
+		dest.Add(addressSrc, tokensSrc)
+	}
+}

--- a/trieTools/zeroBalanceSystemAccountChecker/tokensInputReader.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/tokensInputReader.go
@@ -11,6 +11,11 @@ import (
 	"github.com/ElrondNetwork/elrond-tools-go/trieTools/trieToolsCommon"
 )
 
+const (
+	shardFilePrefix = "shard"
+	shardFileSuffix = ".json"
+)
+
 type addressTokensMapFileReader struct {
 	fileHandler fileHandler
 	marshaller  marshal.Marshalizer
@@ -62,7 +67,7 @@ func (atr *addressTokensMapFileReader) readTokensWithNonce(tokensDir string) (tr
 			return nil, nil, err
 		}
 
-		shardAddressTokensMap[shardID] = addressTokensMapInCurrFile.ShallowClone()
+		shardAddressTokensMap[shardID] = addressTokensMapInCurrFile.Clone()
 		merge(globalAddressTokensMap, addressTokensMapInCurrFile)
 
 		log.Info("read data from",
@@ -77,11 +82,12 @@ func (atr *addressTokensMapFileReader) readTokensWithNonce(tokensDir string) (tr
 }
 
 func getShardID(file string) (uint32, error) {
-	shardIDStr := strings.TrimPrefix(file, "shard")
-	shardIDStr = strings.TrimSuffix(shardIDStr, ".json")
+	shardIDStr := strings.TrimPrefix(file, shardFilePrefix)
+	shardIDStr = strings.TrimSuffix(shardIDStr, shardFileSuffix)
 	shardID, err := strconv.Atoi(shardIDStr)
 	if err != nil {
-		return 0, fmt.Errorf("invalid file input name; expected tokens shard file name to be <shardX.json>, where X = number(e.g. shard0.json)")
+		return 0, fmt.Errorf("invalid file input name: %s; expected tokens shard file name to be <%sX%s>, where X = number(e.g. %s0%s)",
+			file, shardFilePrefix, shardFileSuffix, shardFilePrefix, shardFileSuffix)
 	}
 
 	return uint32(shardID), nil

--- a/trieTools/zeroBalanceSystemAccountChecker/tokensInputReader_test.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/tokensInputReader_test.go
@@ -62,6 +62,7 @@ func TestReadTokensWithNonce(t *testing.T) {
 	sysAccTokensShard1 := map[string]struct{}{
 		"token3-r-0": {},
 		"token3-r-2": {},
+		"token5-r-0": {},
 		"esdt2-rand": {},
 	}
 	addressTokensMapShard1 := trieToolsCommon.NewAddressTokensMap()
@@ -122,11 +123,19 @@ func TestReadTokensWithNonce(t *testing.T) {
 		"token3-r-0": {},
 		"token3-r-1": {},
 		"token3-r-2": {},
+		"token5-r-0": {},
 	})
 	require.Equal(t, expectedGlobalTokensMap, globalTokens)
 
 	expectedShardTokens := make(map[uint32]trieToolsCommon.AddressTokensMap)
-	expectedShardTokens[0] = addressTokensMapShard0
-	expectedShardTokens[1] = addressTokensMapShard1
+	expectedAddressTokensMapShard0 := trieToolsCommon.NewAddressTokensMap()
+	expectedAddressTokensMapShard0.Add(adr1, adr1Tokens)
+	expectedAddressTokensMapShard0.Add(sysAccAddr, sysAccTokensShard0)
+	expectedShardTokens[0] = expectedAddressTokensMapShard0
+
+	expectedAddressTokensMapShard1 := trieToolsCommon.NewAddressTokensMap()
+	expectedAddressTokensMapShard1.Add(adr2, adr2Tokens)
+	expectedAddressTokensMapShard1.Add(sysAccAddr, sysAccTokensShard1)
+	expectedShardTokens[1] = expectedAddressTokensMapShard1
 	require.Equal(t, expectedShardTokens, shardTokens)
 }

--- a/trieTools/zeroBalanceSystemAccountChecker/tokensInputReader_test.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/tokensInputReader_test.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"testing"
+
+	"github.com/ElrondNetwork/elrond-tools-go/trieTools/trieToolsCommon"
+	"github.com/stretchr/testify/require"
+)
+
+type FileHandlerStub struct {
+	OpenCalled    func(name string) (io.Reader, error)
+	ReadAllCalled func(r io.Reader) ([]byte, error)
+	GetwdCalled   func() (dir string, err error)
+	ReadDirCalled func(dirname string) ([]FileInfo, error)
+}
+
+func (fhs *FileHandlerStub) Open(name string) (io.Reader, error) {
+	if fhs.OpenCalled != nil {
+		return fhs.OpenCalled(name)
+	}
+
+	return nil, nil
+}
+
+func (fhs *FileHandlerStub) ReadAll(r io.Reader) ([]byte, error) {
+	if fhs.ReadAllCalled != nil {
+		return fhs.ReadAllCalled(r)
+	}
+
+	return nil, nil
+}
+
+func (fhs *FileHandlerStub) Getwd() (dir string, err error) {
+	if fhs.GetwdCalled != nil {
+		return fhs.GetwdCalled()
+	}
+
+	return "", nil
+}
+
+func (fhs *FileHandlerStub) ReadDir(dirname string) ([]FileInfo, error) {
+	if fhs.ReadDirCalled != nil {
+		return fhs.ReadDirCalled(dirname)
+	}
+
+	return nil, nil
+}
+
+type FileStub struct {
+	NameCalled  func() string
+	IsDirCalled func() bool
+}
+
+func (fs *FileStub) Name() string {
+	if fs.NameCalled != nil {
+		return fs.NameCalled()
+	}
+
+	return ""
+}
+
+func (fs *FileStub) IsDir() bool {
+	if fs.IsDirCalled != nil {
+		return fs.IsDirCalled()
+	}
+
+	return false
+}
+
+type ReaderStub struct {
+	ReadCalled func(p []byte) (n int, err error)
+}
+
+func (rs *ReaderStub) Read(p []byte) (n int, err error) {
+	if rs.ReadCalled != nil {
+		return rs.ReadCalled(p)
+	}
+
+	return 0, nil
+}
+
+func TestReadInputs(t *testing.T) {
+	workingDir := "working-dir"
+	tokensDir := "tokens-dir"
+
+	file1Name := "shard0"
+	file2Name := "shard1"
+
+	file1 := &FileStub{
+		NameCalled: func() string {
+			return file1Name
+		},
+	}
+	file2 := &FileStub{
+		NameCalled: func() string {
+			return file2Name
+		},
+	}
+
+	adr1 := "adr1"
+	sysAccAddr := "sysAccAddr"
+
+	adr1Tokens := map[string]struct{}{
+		"token1-r-0": {},
+		"token2-r-0": {},
+	}
+	sysAccTokensShard0 := map[string]struct{}{
+		"token3-r-0": {},
+		"token3-r-1": {},
+	}
+	addressTokensMapShard0 := trieToolsCommon.NewAddressTokensMap()
+	addressTokensMapShard0.Add(adr1, adr1Tokens)
+	addressTokensMapShard0.Add(sysAccAddr, sysAccTokensShard0)
+
+	adr2 := "adr2"
+	adr2Tokens := map[string]struct{}{
+		"token3-r-0": {},
+		"token4-r-0": {},
+	}
+	sysAccTokensShard1 := map[string]struct{}{
+		"token3-r-0": {},
+		"token3-r-2": {},
+	}
+	addressTokensMapShard1 := trieToolsCommon.NewAddressTokensMap()
+	addressTokensMapShard1.Add(adr2, adr2Tokens)
+	addressTokensMapShard1.Add(sysAccAddr, sysAccTokensShard1)
+
+	openCt := 0
+	fileHandlerStub := &FileHandlerStub{
+		GetwdCalled: func() (dir string, err error) {
+			return workingDir, nil
+		},
+		ReadDirCalled: func(dirname string) ([]FileInfo, error) {
+			require.Equal(t, workingDir+"/"+tokensDir, dirname)
+			return []FileInfo{file1, file2}, nil
+		},
+
+		OpenCalled: func(name string) (io.Reader, error) {
+			openCt++
+
+			switch openCt {
+			case 1:
+				require.Equal(t, workingDir+"/"+tokensDir+"/"+file1Name, name)
+			case 2:
+				require.Equal(t, workingDir+"/"+tokensDir+"/"+file2Name, name)
+			}
+
+			return nil, nil
+		},
+		ReadAllCalled: func(r io.Reader) ([]byte, error) {
+			switch openCt {
+			case 1:
+				return json.Marshal(addressTokensMapShard0.GetMapCopy())
+			case 2:
+				return json.Marshal(addressTokensMapShard1.GetMapCopy())
+			}
+
+			return nil, nil
+		},
+	}
+
+	reader := newAddressTokensMapFileReader(fileHandlerStub)
+	globalTokens, shardTokens, err := reader.readInputs(tokensDir)
+	require.Nil(t, err)
+
+	expectedGlobalTokensMap := trieToolsCommon.NewAddressTokensMap()
+	expectedGlobalTokensMap.Add(adr1, adr1Tokens)
+	expectedGlobalTokensMap.Add(adr2, adr2Tokens)
+	expectedGlobalTokensMap.Add(sysAccAddr, map[string]struct{}{
+		"token3-r-0": {},
+		"token3-r-1": {},
+		"token3-r-2": {},
+	})
+	require.Equal(t, expectedGlobalTokensMap, globalTokens)
+
+	expectedShardTokens := make(map[uint32]trieToolsCommon.AddressTokensMap)
+	expectedShardTokens[0] = addressTokensMapShard0
+	expectedShardTokens[1] = addressTokensMapShard1
+	require.Equal(t, expectedShardTokens, shardTokens)
+}

--- a/trieTools/zeroBalanceSystemAccountChecker/tokensInputReader_test.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/tokensInputReader_test.go
@@ -16,7 +16,7 @@ func TestReadTokensWithNonce(t *testing.T) {
 
 	file1Name := "shard0"
 	file2Name := "shard1"
-	file3Name := "shard1"
+	file3Name := "shard3"
 
 	file1 := &mocks.FileStub{
 		NameCalled: func() string {

--- a/trieTools/zeroBalanceSystemAccountChecker/vars.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/vars.go
@@ -1,7 +1,11 @@
 package main
 
 import (
+	"github.com/ElrondNetwork/elrond-go-core/marshal"
 	logger "github.com/ElrondNetwork/elrond-go-logger"
 )
 
-var log = logger.GetOrCreate("main")
+var (
+	log            = logger.GetOrCreate("main")
+	jsonMarshaller = &marshal.JsonMarshalizer{}
+)

--- a/trieTools/zeroBalanceSystemAccountChecker/vars.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/vars.go
@@ -1,0 +1,7 @@
+package main
+
+import (
+	logger "github.com/ElrondNetwork/elrond-go-logger"
+)
+
+var log = logger.GetOrCreate("main")

--- a/trieTools/zeroBalanceSystemAccountChecker/zeroBalanceSysAccount_test.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/zeroBalanceSysAccount_test.go
@@ -8,9 +8,10 @@ import (
 )
 
 func TestExportSystemAccZeroTokensBalances(t *testing.T) {
-	addressConverter, _ := pubkeyConverter.NewBech32PubkeyConverter(addressLength, log)
-	systemSCAddress := addressConverter.Encode(vmcommon.SystemAccountAddress)
+	addressConverter, err := pubkeyConverter.NewBech32PubkeyConverter(addressLength, log)
+	require.Nil(t, err)
 
+	systemSCAddress := addressConverter.Encode(vmcommon.SystemAccountAddress)
 	globalTokens := make(map[string]map[string]struct{})
 	globalTokens["adr1"] = map[string]struct{}{
 		"token1-r-0": {},
@@ -29,6 +30,7 @@ func TestExportSystemAccZeroTokensBalances(t *testing.T) {
 
 	shardAddressTokenMap := make(map[uint32]map[string]map[string]struct{})
 
+	// Shard 0
 	shardAddressTokenMap[0] = make(map[string]map[string]struct{})
 	shardAddressTokenMap[0][systemSCAddress] = map[string]struct{}{
 		"token1-r-0": {},
@@ -40,6 +42,7 @@ func TestExportSystemAccZeroTokensBalances(t *testing.T) {
 		"token2-r-0": {},
 	}
 
+	// Shard 1
 	shardAddressTokenMap[1] = make(map[string]map[string]struct{})
 	shardAddressTokenMap[1][systemSCAddress] = map[string]struct{}{
 		"token3-r-0": {},

--- a/trieTools/zeroBalanceSystemAccountChecker/zeroBalanceSysAccount_test.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/zeroBalanceSysAccount_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"github.com/ElrondNetwork/elrond-go-core/core/pubkeyConverter"
+	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestExportSystemAccZeroTokensBalances(t *testing.T) {
+	addressConverter, _ := pubkeyConverter.NewBech32PubkeyConverter(addressLength, log)
+	systemSCAddress := addressConverter.Encode(vmcommon.SystemAccountAddress)
+
+	globalTokens := make(map[string]map[string]struct{})
+	globalTokens["adr1"] = map[string]struct{}{
+		"token1-r-0": {},
+		"token2-r-0": {},
+	}
+	globalTokens["adr2"] = map[string]struct{}{
+		"token3-r-0": {},
+	}
+	globalTokens[systemSCAddress] = map[string]struct{}{
+		"token1-r-0": {},
+		"token2-r-0": {},
+		"token3-r-0": {},
+		"token4-r-0": {},
+		"token5-r-0": {},
+	}
+
+	shardAddressTokenMap := make(map[uint32]map[string]map[string]struct{})
+
+	shardAddressTokenMap[0] = make(map[string]map[string]struct{})
+	shardAddressTokenMap[0][systemSCAddress] = map[string]struct{}{
+		"token1-r-0": {},
+		"token2-r-0": {},
+		"token4-r-0": {},
+	}
+	shardAddressTokenMap[0]["adr1"] = map[string]struct{}{
+		"token1-r-0": {},
+		"token2-r-0": {},
+	}
+
+	shardAddressTokenMap[1] = make(map[string]map[string]struct{})
+	shardAddressTokenMap[1][systemSCAddress] = map[string]struct{}{
+		"token3-r-0": {},
+		"token5-r-0": {},
+	}
+	shardAddressTokenMap[1]["adr2"] = map[string]struct{}{
+		"token3-r-0": {},
+	}
+
+	globalExtraTokens, shardExtraTokens, err := exportSystemAccZeroTokensBalances(globalTokens, shardAddressTokenMap)
+	require.Nil(t, err)
+	expectedShardExtraTokens := make(map[uint32]map[string]struct{})
+	expectedShardExtraTokens[0] = map[string]struct{}{
+		"token4-r-0": {},
+	}
+	expectedShardExtraTokens[1] = map[string]struct{}{
+		"token5-r-0": {},
+	}
+	require.Equal(t, expectedShardExtraTokens, shardExtraTokens)
+
+	expectedGlobalExtraTokens := map[string]struct{}{
+		"token4-r-0": {},
+		"token5-r-0": {},
+	}
+	require.Equal(t, expectedGlobalExtraTokens, globalExtraTokens)
+}

--- a/trieTools/zeroBalanceSystemAccountChecker/zeroBalanceSysAccount_test.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/zeroBalanceSysAccount_test.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"testing"
+
 	"github.com/ElrondNetwork/elrond-go-core/core/pubkeyConverter"
+	"github.com/ElrondNetwork/elrond-tools-go/trieTools/trieToolsCommon"
 	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestExportSystemAccZeroTokensBalances(t *testing.T) {
@@ -12,47 +14,49 @@ func TestExportSystemAccZeroTokensBalances(t *testing.T) {
 	require.Nil(t, err)
 
 	systemSCAddress := addressConverter.Encode(vmcommon.SystemAccountAddress)
-	globalTokens := make(map[string]map[string]struct{})
-	globalTokens["adr1"] = map[string]struct{}{
+	globalTokens := trieToolsCommon.NewAddressTokensMap()
+	globalTokens.Add("adr1", map[string]struct{}{
 		"token1-r-0": {},
 		"token2-r-0": {},
-	}
-	globalTokens["adr2"] = map[string]struct{}{
+	})
+	globalTokens.Add("adr2", map[string]struct{}{
 		"token3-r-0": {},
-	}
-	globalTokens[systemSCAddress] = map[string]struct{}{
+	})
+	globalTokens.Add(systemSCAddress, map[string]struct{}{
 		"token1-r-0": {},
 		"token2-r-0": {},
 		"token3-r-0": {},
 		"token4-r-0": {},
 		"token5-r-0": {},
-	}
+	})
 
-	shardAddressTokenMap := make(map[uint32]map[string]map[string]struct{})
+	shardAddressTokenMap := make(map[uint32]trieToolsCommon.AddressTokensMap)
 
 	// Shard 0
-	shardAddressTokenMap[0] = make(map[string]map[string]struct{})
-	shardAddressTokenMap[0][systemSCAddress] = map[string]struct{}{
+	shardAddressTokenMap[0] = trieToolsCommon.NewAddressTokensMap()
+	shardAddressTokenMap[0].Add(systemSCAddress, map[string]struct{}{
 		"token1-r-0": {},
 		"token2-r-0": {},
 		"token4-r-0": {},
-	}
-	shardAddressTokenMap[0]["adr1"] = map[string]struct{}{
+	})
+	shardAddressTokenMap[0].Add("adr1", map[string]struct{}{
 		"token1-r-0": {},
 		"token2-r-0": {},
-	}
+	})
 
 	// Shard 1
-	shardAddressTokenMap[1] = make(map[string]map[string]struct{})
-	shardAddressTokenMap[1][systemSCAddress] = map[string]struct{}{
+	shardAddressTokenMap[1] = trieToolsCommon.NewAddressTokensMap()
+	shardAddressTokenMap[1].Add(systemSCAddress, map[string]struct{}{
 		"token3-r-0": {},
 		"token5-r-0": {},
-	}
-	shardAddressTokenMap[1]["adr2"] = map[string]struct{}{
+	})
+	shardAddressTokenMap[1].Add("adr2", map[string]struct{}{
 		"token3-r-0": {},
-	}
+	})
 
-	globalExtraTokens, shardExtraTokens, err := exportSystemAccZeroTokensBalances(globalTokens, shardAddressTokenMap)
+	exporter, err := newZeroTokensBalancesExporter(addressConverter)
+	require.Nil(t, err)
+	globalExtraTokens, shardExtraTokens, err := exporter.getExtraTokens(globalTokens, shardAddressTokenMap)
 	require.Nil(t, err)
 	expectedShardExtraTokens := make(map[uint32]map[string]struct{})
 	expectedShardExtraTokens[0] = map[string]struct{}{

--- a/trieTools/zeroBalanceSystemAccountChecker/zeroTokensBalancesExporter.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/zeroTokensBalancesExporter.go
@@ -68,7 +68,7 @@ func getGlobalExtraTokens(allAddressesTokensMap trieToolsCommon.AddressTokensMap
 }
 
 func getAllTokensWithoutSystemAccount(allAddressesTokensMap trieToolsCommon.AddressTokensMap, systemSCAddress string) map[string]struct{} {
-	mapCopy := allAddressesTokensMap.ShallowClone()
+	mapCopy := allAddressesTokensMap.Clone()
 	mapCopy.Delete(systemSCAddress)
 
 	return mapCopy.GetAllTokens()

--- a/trieTools/zeroBalanceSystemAccountChecker/zeroTokensBalancesExporter.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/zeroTokensBalancesExporter.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/ElrondNetwork/elrond-go-core/core"
+	"github.com/ElrondNetwork/elrond-tools-go/trieTools/trieToolsCommon"
+	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
+)
+
+type zeroTokensBalancesExporter struct {
+	pubKeyConverter core.PubkeyConverter
+}
+
+func newZeroTokensBalancesExporter(pubKeyConverter core.PubkeyConverter) (*zeroTokensBalancesExporter, error) {
+	if pubKeyConverter.IsInterfaceNil() {
+		return nil, errors.New("nil pub key converter provided")
+	}
+
+	return &zeroTokensBalancesExporter{
+		pubKeyConverter: pubKeyConverter,
+	}, nil
+}
+
+func (ztb *zeroTokensBalancesExporter) getExtraTokens(
+	globalAddressTokensMap trieToolsCommon.AddressTokensMap,
+	shardAddressTokenMap map[uint32]trieToolsCommon.AddressTokensMap,
+) (map[string]struct{}, map[uint32]map[string]struct{}, error) {
+	systemSCAddress := ztb.pubKeyConverter.Encode(vmcommon.SystemAccountAddress)
+	globalExtraTokens, err := getGlobalExtraTokens(globalAddressTokensMap, systemSCAddress)
+	if err != nil {
+		return nil, nil, err
+	}
+	log.Info("found", "global num of extra tokens", len(globalExtraTokens))
+
+	shardExtraTokens := make(map[uint32]map[string]struct{})
+	for shardID, addressTokensMap := range shardAddressTokenMap {
+		if !addressTokensMap.HasAddress(systemSCAddress) {
+			return nil, nil, fmt.Errorf("no system account address(%s) found in shard = %v", systemSCAddress, shardID)
+		}
+
+		shardTokensInSystemAccAddress := addressTokensMap.GetTokens(systemSCAddress)
+		extraTokensInShard := intersection(globalExtraTokens, shardTokensInSystemAccAddress)
+		log.Info("found", "shard", shardID, "num tokens in system account", len(shardTokensInSystemAccAddress), "num extra tokens", len(extraTokensInShard))
+		shardExtraTokens[shardID] = extraTokensInShard
+	}
+
+	if !sanityCheckExtraTokens(shardExtraTokens, globalExtraTokens) {
+		return nil, nil, errors.New("sanity check for exported tokens failed")
+	}
+
+	return globalExtraTokens, shardExtraTokens, nil
+}
+
+func getGlobalExtraTokens(allAddressesTokensMap trieToolsCommon.AddressTokensMap, systemSCAddress string) (map[string]struct{}, error) {
+	if !allAddressesTokensMap.HasAddress(systemSCAddress) {
+		return nil, fmt.Errorf("no system account address(%s) found", systemSCAddress)
+	}
+
+	allTokensInSystemSCAddress := allAddressesTokensMap.GetTokens(systemSCAddress)
+	allTokens := getAllTokensWithoutSystemAccount(allAddressesTokensMap, systemSCAddress)
+	log.Info("found",
+		"global num of tokens in all addresses without system account", len(allTokens),
+		"global num of tokens in system sc address", len(allTokensInSystemSCAddress))
+
+	return getExtraTokens(allTokens, allTokensInSystemSCAddress), nil
+}
+
+func getAllTokensWithoutSystemAccount(allAddressesTokensMap trieToolsCommon.AddressTokensMap, systemSCAddress string) map[string]struct{} {
+	mapCopy := allAddressesTokensMap.ShallowClone()
+	mapCopy.Delete(systemSCAddress)
+
+	return mapCopy.GetAllTokens()
+}
+
+func getExtraTokens(allTokens, allTokensInSystemSCAddress map[string]struct{}) map[string]struct{} {
+	extraTokens := make(map[string]struct{})
+	for tokenInSystemSC := range allTokensInSystemSCAddress {
+		_, exists := allTokens[tokenInSystemSC]
+		if !exists {
+			extraTokens[tokenInSystemSC] = struct{}{}
+		}
+	}
+
+	log.Info("found", "num of sfts/nfts/metaesdts metadata only found in system sc address", len(extraTokens))
+	return extraTokens
+}
+
+func intersection(globalTokens, shardTokens map[string]struct{}) map[string]struct{} {
+	ret := make(map[string]struct{})
+	for token := range shardTokens {
+		_, found := globalTokens[token]
+		if found {
+			ret[token] = struct{}{}
+		}
+	}
+
+	return ret
+}
+
+func sanityCheckExtraTokens(shardExtraTokensMap map[uint32]map[string]struct{}, globalExtraTokens map[string]struct{}) bool {
+	allMergedExtraTokens := make(map[string]struct{})
+	for _, extraTokensInShard := range shardExtraTokensMap {
+		for extraToken := range extraTokensInShard {
+			allMergedExtraTokens[extraToken] = struct{}{}
+		}
+	}
+
+	return checkSameMap(allMergedExtraTokens, globalExtraTokens)
+}
+
+func checkSameMap(map1, map2 map[string]struct{}) bool {
+	if len(map1) != len(map2) {
+		return false
+	}
+
+	for elemInMap1 := range map1 {
+		_, foundInMap2 := map2[elemInMap1]
+		if !foundInMap2 {
+			return false
+		}
+	}
+
+	return true
+}

--- a/trieTools/zeroBalanceSystemAccountChecker/zeroTokensBalancesExporter_test.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/zeroTokensBalancesExporter_test.go
@@ -28,6 +28,7 @@ func TestExportSystemAccZeroTokensBalances(t *testing.T) {
 		"token3-r-0": {},
 		"token4-r-0": {},
 		"token5-r-0": {},
+		"token6-r-0": {},
 	})
 
 	shardAddressTokenMap := make(map[uint32]trieToolsCommon.AddressTokensMap)
@@ -54,6 +55,12 @@ func TestExportSystemAccZeroTokensBalances(t *testing.T) {
 		"token3-r-0": {},
 	})
 
+	// Shard 2
+	shardAddressTokenMap[2] = trieToolsCommon.NewAddressTokensMap()
+	shardAddressTokenMap[2].Add(systemSCAddress, map[string]struct{}{
+		"token6-r-0": {},
+	})
+
 	exporter, err := newZeroTokensBalancesExporter(addressConverter)
 	require.Nil(t, err)
 
@@ -66,11 +73,15 @@ func TestExportSystemAccZeroTokensBalances(t *testing.T) {
 	expectedShardExtraTokens[1] = map[string]struct{}{
 		"token5-r-0": {},
 	}
+	expectedShardExtraTokens[2] = map[string]struct{}{
+		"token6-r-0": {},
+	}
 	require.Equal(t, expectedShardExtraTokens, shardExtraTokens)
 
 	expectedGlobalExtraTokens := map[string]struct{}{
 		"token4-r-0": {},
 		"token5-r-0": {},
+		"token6-r-0": {},
 	}
 	require.Equal(t, expectedGlobalExtraTokens, globalExtraTokens)
 }


### PR DESCRIPTION
Description
--

- Created tool that exports **all tokens(with nonce)** that are stored in system account, but not in any other address( <=> tokens with 0 balance/supply in any other account)
- This tool reads multiple maps <address, tokens> from each shard(input is expected to be json files, as the ones exported by `tokensExporter` tool. see [this PR description](https://github.com/ElrondNetwork/elrond-tools-go/pull/19)) . Then, it merges all maps in a single one and checks which tokens are only found in system account, but not in any other address.
- If called with flag `--cross-check`, before exporting the final tokens list, it will **cross check the results** by:
1. Checking if token is stored in indexer. If found; check indexer addresses which hold this token. For each address that supposedly holds the token, check step 2.
2. Check if token exists in address's data trie(gateway call). If it exists; then this token will not be exported. Otherwise, we export the token and consider it to be an indexer issue=> log a warning.
- Since **we use multi search queries in indexer (10.000 queries/request)**(which are not public), I've added `config.toml` which should be filled with credentials


How to use it
--

- This tool exports map < shardID, tokens > in json format **after reading input data frum multiple shards**. Therefore, after preparing the input(using  [the tool mentioned above](https://github.com/ElrondNetwork/elrond-tools-go/pull/19)), you should create an `input` folder with data from each shard.


Example
--
-> Input directory
|
|--`input`---| ->`shrad0.json` -> store here `tokensExporter`' s tool output for **shard0**
|________ |-->`shrad1.json` -> store here `tokensExporter`' s tool output for **shard1**
|________ |-->`shrad2.json` -> store here `tokensExporter`' s tool output for **shard2**
|

-> **Run**:
`
./zeroBalanceSystemAccountChecker --tokens-dir input --outfile=extraTokens.json --cross-check
`

-> **If called with `--cross-check` flag**:

- If a token is found in indexer:
`
[DEBUG]   found token in indexer with hits/accounts token =  MEXFARML-28d646-19e103 hits/accounts = 1 
`
`
[DEBUG]   checking gateway if token still exists in trie  token = MEXFARML-28d646-19e103 address = erd1qqqqqqqqqqqqqpgqrc4pg2xarca9z34njcxeur622qmfjp8w2jps89fxnl 
`

There are two possibilites:
1. Indexer problem => one will see a  `WARN` log
`
[WARN]   possible indexer problem                 token = MEXFARML-28d646-19e103 hit in address = erd1qqqqqqqqqqqqqpgqrc4pg2xarca9z34njcxeur622qmfjp8w2jps89fxnl found in trie = false 
`
2. Snapshot problem => token still exists => one will see an `ERROR` log
`
[ERROR]   cross-check failed; found token which is still in other address token = MEXFARML-28d646-19e103 balance  = 6059787621742865721045753 address = erd1qqqqqqqqqqqqqpgq8xwzu82v8ex3h4ayl5lsvxqxnhecpwyvwe0sf2qj4e 
`

At the end, one should see an output like this:

`
[ERROR]   found tokens with balances that still exist in other accounts; probably found in pending mbs during snapshot; will remove them from exported tokens  tokens= [LKFARM-9d1ea8-860984 HOKI-518891-0535 MAFIA-bd0abc-94 SYNTHS-6ba972-012b] 
`
`
[INFO]   writing result in                       file = extraTokens.json 
`
`
[INFO]   finished exporting zero balance tokens map 
`

-> **Output in `extraTokens.json` should look like**:
```
{
 "0": {
  "ZZZ0-c5aa13-01": {},
  "ZZZ1-c5aa13-01": {},
  ...
 },
 "1": {
  "AAA0-f1fac9-01": {},
  "AAA0-f1fac9-02": {},
  ...
...
