### PR TITLE
Unit tests for tokenBalanceGetter

### DIFF
--- a/trieTools/zeroBalanceSystemAccountChecker/errors.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/errors.go
@@ -3,3 +3,7 @@ package main
 import "errors"
 
 var errCouldNotGetBalance = errors.New("could not get balance")
+
+var errNilHttpResponse = errors.New("received nil http response")
+
+var errNilHttpResponseBody = errors.New("received nil http response body")

--- a/trieTools/zeroBalanceSystemAccountChecker/errors.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/errors.go
@@ -1,0 +1,5 @@
+package main
+
+import "errors"
+
+var errCouldNotGetBalance = errors.New("could not get balance")

--- a/trieTools/zeroBalanceSystemAccountChecker/extraTokensCrossChecker.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/extraTokensCrossChecker.go
@@ -7,10 +7,7 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-const (
-	maxRequestsRetrial = 10
-	multipleSearchBulk = 10000
-)
+const multipleSearchBulk = 10000
 
 type extraTokensChecker struct {
 	nftBalancesGetter tokenBalancesGetter

--- a/trieTools/zeroBalanceSystemAccountChecker/tokenBalanceGetter.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/tokenBalanceGetter.go
@@ -68,11 +68,11 @@ func (tbg *tokenBalanceGetter) fetchTokenBalanceWithRetrial(address, tokenID str
 
 func (tbg *tokenBalanceGetter) getBody(response *http.Response) (string, error) {
 	if response == nil {
-		return "", fmt.Errorf("got nil http response")
+		return "", errNilHttpResponse
 	}
 
 	if response.Body == nil {
-		return "", fmt.Errorf("got nil body in http response")
+		return "", errNilHttpResponseBody
 	}
 
 	bodyBytes, err := io.ReadAll(response.Body)

--- a/trieTools/zeroBalanceSystemAccountChecker/tokenBalanceGetter.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/tokenBalanceGetter.go
@@ -50,6 +50,8 @@ func (tbg *tokenBalanceGetter) fetchTokenBalanceWithRetrial(address, tokenID str
 			return gjson.Get(body, "data.tokenData.balance").String(), nil
 		}
 
+		ctRetrials++
+
 		log.Warn("could not get balance; retrying...",
 			"address", address,
 			"tokenID", tokenID,
@@ -57,14 +59,20 @@ func (tbg *tokenBalanceGetter) fetchTokenBalanceWithRetrial(address, tokenID str
 			"error http", errHttp,
 			"error body", errBody,
 			"num retrials", ctRetrials)
-
-		ctRetrials++
 	}
 
-	return "", fmt.Errorf("could not get adress's tokens = %s after num of retrials = %d", address, maxRequestsRetrial)
+	return "", fmt.Errorf("%w; address = %s after num of retrials = %d", errCouldNotGetBalance, address, maxRequestsRetrial)
 }
 
 func (tbg *tokenBalanceGetter) getBody(response *http.Response) (string, error) {
+	if response == nil {
+		return "", fmt.Errorf("got nil http response")
+	}
+
+	if response.Body == nil {
+		return "", fmt.Errorf("got nil body in http response")
+	}
+
 	bodyBytes, err := io.ReadAll(response.Body)
 	if err != nil {
 		return "", fmt.Errorf("could not ready bytes from body; error: %w", err)

--- a/trieTools/zeroBalanceSystemAccountChecker/tokenBalanceGetter.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/tokenBalanceGetter.go
@@ -10,6 +10,8 @@ import (
 	"github.com/tidwall/gjson"
 )
 
+const maxRequestsRetrial = 10
+
 type get func(url string) (resp *http.Response, err error)
 
 type tokenBalanceGetter struct {

--- a/trieTools/zeroBalanceSystemAccountChecker/tokenBalanceGetter_test.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/tokenBalanceGetter_test.go
@@ -41,6 +41,7 @@ func TestTokenBalanceGetter_GetBalance(t *testing.T) {
 		}
 
 		tbg := newTokenBalanceGetter(proxyUrl, getFunc)
+
 		balance, err := tbg.getBalance(address, token)
 		require.Nil(t, err)
 		require.Equal(t, expectedBalance, balance)
@@ -72,6 +73,7 @@ func TestTokenBalanceGetter_GetBalance(t *testing.T) {
 		}
 
 		tbg := newTokenBalanceGetter(proxyUrl, getFunc)
+
 		balance, err := tbg.getBalance(address, token)
 		require.Nil(t, err)
 		require.Equal(t, expectedBalance, balance)
@@ -86,13 +88,14 @@ func TestTokenBalanceGetter_GetBalance(t *testing.T) {
 		}
 
 		tbg := newTokenBalanceGetter(proxyUrl, getFunc)
+
 		balance, err := tbg.getBalance(address, token)
+		require.Empty(t, balance)
 		require.Equal(t, maxRequestsRetrial, errorCt)
+
 		require.NotNil(t, err)
 		require.ErrorIs(t, err, errCouldNotGetBalance)
 		require.True(t, strings.Contains(err.Error(), address))
 		require.True(t, strings.Contains(err.Error(), fmt.Sprintf("%d", maxRequestsRetrial)))
-
-		require.Empty(t, balance)
 	})
 }

--- a/trieTools/zeroBalanceSystemAccountChecker/tokenBalanceGetter_test.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/tokenBalanceGetter_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func createTokenBalanceBodyResponse(balance, error string) string {
+	return fmt.Sprintf(` {
+		"data": {
+			"tokenData": {
+				"balance": %s,
+			}
+		},
+		"error": "%s",
+			"code": "successful"
+	}`, balance, error)
+}
+
+func TestTokenBalanceGetter_GetBalance(t *testing.T) {
+	proxyUrl := "proxy"
+	address := "erd1abc"
+	token := "token-rand-0f"
+	expectedBalance := "44112"
+
+	t.Run("should work without errors", func(t *testing.T) {
+		getFunc := func(url string) (resp *http.Response, err error) {
+			require.Equal(t, fmt.Sprintf("%s/address/%s/nft/%s/nonce/%d", proxyUrl, address, "token-rand", 15), url)
+
+			body := createTokenBalanceBodyResponse(expectedBalance, "")
+			return &http.Response{
+				Body: ioutil.NopCloser(bytes.NewBufferString(body)),
+			}, nil
+		}
+
+		tbg := newTokenBalanceGetter(proxyUrl, getFunc)
+		balance, err := tbg.getBalance(address, token)
+		require.Nil(t, err)
+		require.Equal(t, expectedBalance, balance)
+	})
+
+	t.Run("should work after few retrials", func(t *testing.T) {
+		body := ""
+		errorCt := 0
+		getFunc := func(url string) (resp *http.Response, err error) {
+			require.Equal(t, fmt.Sprintf("%s/address/%s/nft/%s/nonce/%d", proxyUrl, address, "token-rand", 15), url)
+
+			errorCt++
+			switch errorCt {
+			case 1:
+				return nil, errors.New("first error")
+			case 2:
+				body = createTokenBalanceBodyResponse("0", "second error")
+			case 3:
+				return &http.Response{Body: nil}, nil
+			case 4:
+				body = createTokenBalanceBodyResponse(expectedBalance, "")
+			default:
+				require.Fail(t, "should not do another retrial")
+			}
+
+			return &http.Response{
+				Body: ioutil.NopCloser(bytes.NewBufferString(body)),
+			}, nil
+		}
+
+		tbg := newTokenBalanceGetter(proxyUrl, getFunc)
+		balance, err := tbg.getBalance(address, token)
+		require.Nil(t, err)
+		require.Equal(t, expectedBalance, balance)
+	})
+
+	t.Run("could not get balance after max retrials", func(t *testing.T) {
+		errorCt := 0
+		getFunc := func(url string) (resp *http.Response, err error) {
+			require.Equal(t, fmt.Sprintf("%s/address/%s/nft/%s/nonce/%d", proxyUrl, address, "token-rand", 15), url)
+			errorCt++
+			return nil, errors.New("local error")
+		}
+
+		tbg := newTokenBalanceGetter(proxyUrl, getFunc)
+		balance, err := tbg.getBalance(address, token)
+		require.Equal(t, maxRequestsRetrial, errorCt)
+		require.NotNil(t, err)
+		require.ErrorIs(t, err, errCouldNotGetBalance)
+		require.True(t, strings.Contains(err.Error(), address))
+		require.True(t, strings.Contains(err.Error(), fmt.Sprintf("%d", maxRequestsRetrial)))
+
+		require.Empty(t, balance)
+	})
+}

--- a/trieTools/zeroBalanceSystemAccountChecker/tokenBalanceGetter_test.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/tokenBalanceGetter_test.go
@@ -20,7 +20,6 @@ func createTokenBalanceBodyResponse(balance, error string) string {
 			}
 		},
 		"error": "%s",
-			"code": "successful"
 	}`, balance, error)
 }
 


### PR DESCRIPTION
- Added unit tests for `tokenBalanceGetter`
- Fixed possible nil pointer dereference in `http.Response` and `http.Response.Body`