### PR TITLE
En 13093 unit tests create shard txs data map

### DIFF
--- a/tokensRemover/metaDataRemover/errors.go
+++ b/tokensRemover/metaDataRemover/errors.go
@@ -3,3 +3,5 @@ package main
 import "errors"
 
 var errInvalidTokenFormat = errors.New("invalid token format")
+
+var errCouldNotConvertNonceToBigInt = errors.New("could not convert nonce to big int")

--- a/tokensRemover/metaDataRemover/errors.go
+++ b/tokensRemover/metaDataRemover/errors.go
@@ -1,0 +1,5 @@
+package main
+
+import "errors"
+
+var errInvalidTokenFormat = errors.New("invalid token format")

--- a/tokensRemover/metaDataRemover/tokenSorting.go
+++ b/tokensRemover/metaDataRemover/tokenSorting.go
@@ -41,7 +41,7 @@ func sortTokensIDByNonce(tokens map[string]struct{}) (map[string][]uint64, error
 	for token := range tokens {
 		splits := strings.Split(token, "-")
 		if len(splits) != 3 {
-			return nil, fmt.Errorf("found invalid format in token = %s; expected [ticker-randSequence-nonce]", token)
+			return nil, fmt.Errorf("found %w = %s; expected format = [ticker-randSequence-nonce]", errInvalidTokenFormat, token)
 		}
 
 		tokenID := splits[0] + "-" + splits[1] // ticker-randSequence

--- a/tokensRemover/metaDataRemover/tokenSorting.go
+++ b/tokensRemover/metaDataRemover/tokenSorting.go
@@ -49,7 +49,7 @@ func sortTokensIDByNonce(tokens map[string]struct{}) (map[string][]uint64, error
 		nonceBI := big.NewInt(0)
 		_, ok := nonceBI.SetString(nonceStr, 16)
 		if !ok {
-			return nil, fmt.Errorf("could not convert nonce to big int; token = %s, nonce string = %s", tokenID, nonceStr)
+			return nil, fmt.Errorf("%w; token = %s, nonce string = %s", errCouldNotConvertNonceToBigInt, tokenID, nonceStr)
 		}
 
 		ret[tokenID] = append(ret[tokenID], nonceBI.Uint64())

--- a/tokensRemover/metaDataRemover/txDataFormater_test.go
+++ b/tokensRemover/metaDataRemover/txDataFormater_test.go
@@ -206,6 +206,8 @@ func TestCreateShardTxsDataMap(t *testing.T) {
 	t.Parallel()
 
 	t.Run("invalid token format, should return error", func(t *testing.T) {
+		t.Parallel()
+
 		tokensShard0 := map[string]struct{}{
 			"token1-r-04": {},
 		}
@@ -225,6 +227,8 @@ func TestCreateShardTxsDataMap(t *testing.T) {
 	})
 
 	t.Run("should work", func(t *testing.T) {
+		t.Parallel()
+
 		tokensShard0 := map[string]struct{}{
 			"token1-r-04": {},
 			"token2-r-01": {},


### PR DESCRIPTION
- Added tests for `createShardTxsDataMap` - (more complex data formatting tests can be found in the already written test: `TestCreateTxsData`); 
- Added unit tests for error cases in `createShardTxsDataMap`