### PR TITLE
En 13097 unit tests pems input reader

### DIFF
--- a/tokensRemover/go.mod
+++ b/tokensRemover/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/ElrondNetwork/elrond-go-logger v1.0.7
 	github.com/ElrondNetwork/elrond-sdk-erdgo v1.1.2-0.20220817085202-41824b2249e5
-	github.com/ElrondNetwork/elrond-tools-go/trieTools v0.0.0-20220902141155-9219e6c4577f
+	github.com/ElrondNetwork/elrond-tools-go/trieTools v0.0.0-20220913084212-c356e1f153f8
 	github.com/pelletier/go-toml v1.9.3
 	github.com/stretchr/testify v1.8.0
 	github.com/urfave/cli v1.22.9

--- a/tokensRemover/go.sum
+++ b/tokensRemover/go.sum
@@ -71,8 +71,8 @@ github.com/ElrondNetwork/elrond-go-logger v1.0.7/go.mod h1:cBfgx0ST/CJx8jrxJSC5a
 github.com/ElrondNetwork/elrond-sdk-erdgo v1.1.2-0.20220817085202-41824b2249e5 h1:MCLJUX4IgS5zocb/AUuP8gccQ9O3cI1QkeU4DDD0Kmg=
 github.com/ElrondNetwork/elrond-sdk-erdgo v1.1.2-0.20220817085202-41824b2249e5/go.mod h1:WqknC6O3Z94dBte7s7LVYmg30KtuJxhGvm0EQ3RknyE=
 github.com/ElrondNetwork/elrond-tools-go/elasticreindexer v0.0.0-20220822122240-fd32ce986e4c/go.mod h1:tdcxQ73bFf0JQLcpFmZ8E0mONYEErTV1mEG6IFlgtjQ=
-github.com/ElrondNetwork/elrond-tools-go/trieTools v0.0.0-20220902141155-9219e6c4577f h1:nYZy91R7GKZkxC/HzoRmQb5VthlXQRwmAqalu832Fqs=
-github.com/ElrondNetwork/elrond-tools-go/trieTools v0.0.0-20220902141155-9219e6c4577f/go.mod h1:SCKT+uf3+F8WPkYf4a5xGfg31ay6WpWCihvYYAvP+5o=
+github.com/ElrondNetwork/elrond-tools-go/trieTools v0.0.0-20220913084212-c356e1f153f8 h1:xdlSJeauON4oomfs2E+duPURResicghZXFqbSsCcR2o=
+github.com/ElrondNetwork/elrond-tools-go/trieTools v0.0.0-20220913084212-c356e1f153f8/go.mod h1:SCKT+uf3+F8WPkYf4a5xGfg31ay6WpWCihvYYAvP+5o=
 github.com/ElrondNetwork/elrond-vm-common v1.1.0/go.mod h1:w3i6f8uiuRkE68Ie/gebRcLgTuHqvruJSYrFyZWuLrE=
 github.com/ElrondNetwork/elrond-vm-common v1.2.9/go.mod h1:B/Y8WiqHyDd7xsjNYsaYbVMp1jQgQ+z4jTJkFvj/EWI=
 github.com/ElrondNetwork/elrond-vm-common v1.3.4/go.mod h1:B/Y8WiqHyDd7xsjNYsaYbVMp1jQgQ+z4jTJkFvj/EWI=

--- a/tokensRemover/metaDataRemover/errors.go
+++ b/tokensRemover/metaDataRemover/errors.go
@@ -5,3 +5,7 @@ import "errors"
 var errInvalidTokenFormat = errors.New("invalid token format")
 
 var errCouldNotConvertNonceToBigInt = errors.New("could not convert nonce to big int")
+
+var errNilPemProvider = errors.New("received nil pem provider")
+
+var errNilFileHandler = errors.New("received nil file handler")

--- a/tokensRemover/metaDataRemover/main.go
+++ b/tokensRemover/metaDataRemover/main.go
@@ -7,6 +7,7 @@ import (
 	logger "github.com/ElrondNetwork/elrond-go-logger"
 	"github.com/ElrondNetwork/elrond-tools-go/tokensRemover/metaDataRemover/config"
 	"github.com/ElrondNetwork/elrond-tools-go/trieTools/trieToolsCommon"
+	"github.com/ElrondNetwork/elrond-tools-go/trieTools/zeroBalanceSystemAccountChecker/common"
 	"github.com/pelletier/go-toml"
 	"github.com/urfave/cli"
 )
@@ -71,12 +72,22 @@ func startProcess(c *cli.Context) error {
 		return err
 	}
 
-	shardPemsDataMap, err := readPemsData(flagsConfig.Pems, &pemDataProvider{})
+	shardPemsDataMap, err := getShardPemsDataMap(flagsConfig.Pems)
 	if err != nil {
 		return err
 	}
 
 	return createShardTxs(flagsConfig.Outfile, cfg, shardPemsDataMap, shardTxsDataMap)
+}
+
+func getShardPemsDataMap(pemsFile string) (map[uint32]*skAddress, error) {
+	osFileHandler := common.NewOSFileHandler()
+	pemsReader, err := newPemsDataReader(&pemDataProvider{}, osFileHandler)
+	if err != nil {
+		return nil, err
+	}
+
+	return pemsReader.readPemsData(pemsFile)
 }
 
 func loadConfig() (*config.Config, error) {

--- a/tokensRemover/metaDataRemover/pemInputReader_test.go
+++ b/tokensRemover/metaDataRemover/pemInputReader_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/ElrondNetwork/elrond-sdk-erdgo/data"
+	"github.com/ElrondNetwork/elrond-tools-go/trieTools/zeroBalanceSystemAccountChecker/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadPemsData_RealData(t *testing.T) {
+	pemsReader, _ := newPemsDataReader(&pemDataProvider{}, common.NewOSFileHandler())
+	pemsData, err := pemsReader.readPemsData("testDataPem")
+	require.Nil(t, err)
+
+	addrShard0, err := data.NewAddressFromBech32String("erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th")
+	require.Nil(t, err)
+	skShard0, err := hex.DecodeString("413f42575f7f26fad3317a778771212fdb80245850981e48b58a4f25e344e8f9")
+	require.Nil(t, err)
+
+	addrShard1, err := data.NewAddressFromBech32String("erd1k2s324ww2g0yj38qn2ch2jwctdy8mnfxep94q9arncc6xecg3xaq6mjse8")
+	require.Nil(t, err)
+	skShard1, err := hex.DecodeString("e253a571ca153dc2aee845819f74bcc9773b0586edead15a94cb7235a5027436")
+	require.Nil(t, err)
+
+	expectedPemsData := map[uint32]*skAddress{
+		0: {
+			secretKey: skShard0,
+			address:   addrShard0,
+		},
+		1: {
+			secretKey: skShard1,
+			address:   addrShard1,
+		},
+	}
+	require.Equal(t, pemsData, expectedPemsData)
+}

--- a/tokensRemover/metaDataRemover/pemInputReader_test.go
+++ b/tokensRemover/metaDataRemover/pemInputReader_test.go
@@ -9,6 +9,34 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestNewPemsDataReader(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil pem data provider, should err", func(t *testing.T) {
+		t.Parallel()
+
+		pdr, err := newPemsDataReader(nil, common.NewOSFileHandler())
+		require.Nil(t, pdr)
+		require.Equal(t, errNilPemProvider, err)
+	})
+
+	t.Run("nil file handler, should err", func(t *testing.T) {
+		t.Parallel()
+
+		pdr, err := newPemsDataReader(&pemDataProvider{}, nil)
+		require.Nil(t, pdr)
+		require.Equal(t, errNilFileHandler, err)
+	})
+
+	t.Run("should work", func(t *testing.T) {
+		t.Parallel()
+
+		pdr, err := newPemsDataReader(&pemDataProvider{}, common.NewOSFileHandler())
+		require.NotNil(t, pdr)
+		require.Nil(t, err)
+	})
+}
+
 func TestReadPemsData_RealData(t *testing.T) {
 	pemsReader, _ := newPemsDataReader(&pemDataProvider{}, common.NewOSFileHandler())
 	pemsData, err := pemsReader.readPemsData("testDataPem")

--- a/tokensRemover/metaDataRemover/testDataPem/shard0.pem
+++ b/tokensRemover/metaDataRemover/testDataPem/shard0.pem
@@ -1,0 +1,5 @@
+-----BEGIN PRIVATE KEY for erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th-----
+NDEzZjQyNTc1ZjdmMjZmYWQzMzE3YTc3ODc3MTIxMmZkYjgwMjQ1ODUwOTgxZTQ4
+YjU4YTRmMjVlMzQ0ZThmOTAxMzk0NzJlZmY2ODg2NzcxYTk4MmYzMDgzZGE1ZDQy
+MWYyNGMyOTE4MWU2Mzg4ODIyOGRjODFjYTYwZDY5ZTE=
+-----END PRIVATE KEY for erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th-----

--- a/tokensRemover/metaDataRemover/testDataPem/shard1.pem
+++ b/tokensRemover/metaDataRemover/testDataPem/shard1.pem
@@ -1,0 +1,5 @@
+-----BEGIN PRIVATE KEY for erd1k2s324ww2g0yj38qn2ch2jwctdy8mnfxep94q9arncc6xecg3xaq6mjse8-----
+ZTI1M2E1NzFjYTE1M2RjMmFlZTg0NTgxOWY3NGJjYzk3NzNiMDU4NmVkZWFkMTVh
+OTRjYjcyMzVhNTAyNzQzNmIyYTExNTU1Y2U1MjFlNDk0NGUwOWFiMTc1NDlkODVi
+NDg3ZGNkMjZjODRiNTAxN2EzOWUzMWEzNjcwODg5YmE=
+-----END PRIVATE KEY for erd1k2s324ww2g0yj38qn2ch2jwctdy8mnfxep94q9arncc6xecg3xaq6mjse8-----

--- a/trieTools/zeroBalanceSystemAccountChecker/common/fileHandler.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/common/fileHandler.go
@@ -1,17 +1,16 @@
-package main
+package common
 
 import (
 	"io"
 	"io/ioutil"
 	"os"
-
-	"github.com/ElrondNetwork/elrond-tools-go/trieTools/zeroBalanceSystemAccountChecker/common"
 )
 
 type osFileHandler struct {
 }
 
-func newOSFileHandler() *osFileHandler {
+// NewOSFileHandler creates a new instance of os file handler
+func NewOSFileHandler() *osFileHandler {
 	return &osFileHandler{}
 }
 
@@ -31,13 +30,13 @@ func (fh *osFileHandler) Getwd() (dir string, err error) {
 }
 
 // ReadDir reads the directory and returns no directory entries along with the error.
-func (fh *osFileHandler) ReadDir(dirname string) ([]common.FileInfo, error) {
+func (fh *osFileHandler) ReadDir(dirname string) ([]FileInfo, error) {
 	files, err := ioutil.ReadDir(dirname)
 	if err != nil {
 		return nil, err
 	}
 
-	ret := make([]common.FileInfo, 0, len(files))
+	ret := make([]FileInfo, 0, len(files))
 	for _, f := range files {
 		ret = append(ret, f)
 	}

--- a/trieTools/zeroBalanceSystemAccountChecker/common/interface.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/common/interface.go
@@ -1,7 +1,17 @@
 package common
 
+import "io"
+
 // FileInfo should provide basic information about a file
 type FileInfo interface {
 	Name() string
 	IsDir() bool
+}
+
+// FileHandler defines what a sys file handler should do (e.g. read directories, get working dir)
+type FileHandler interface {
+	Open(name string) (io.Reader, error)
+	ReadAll(r io.Reader) ([]byte, error)
+	Getwd() (dir string, err error)
+	ReadDir(dirname string) ([]FileInfo, error)
 }

--- a/trieTools/zeroBalanceSystemAccountChecker/interface.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/interface.go
@@ -1,11 +1,5 @@
 package main
 
-import (
-	"io"
-
-	"github.com/ElrondNetwork/elrond-tools-go/trieTools/zeroBalanceSystemAccountChecker/common"
-)
-
 type crossTokenChecker interface {
 	crossCheckExtraTokens(tokens map[string]struct{}) ([]string, error)
 }
@@ -16,11 +10,4 @@ type tokenBalancesGetter interface {
 
 type elasticMultiSearchClient interface {
 	GetMultiple(index string, requests []string) ([]byte, error)
-}
-
-type fileHandler interface {
-	Open(name string) (io.Reader, error)
-	ReadAll(r io.Reader) ([]byte, error)
-	Getwd() (dir string, err error)
-	ReadDir(dirname string) ([]common.FileInfo, error)
 }

--- a/trieTools/zeroBalanceSystemAccountChecker/main.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ElrondNetwork/elrond-tools-go/elasticreindexer/config"
 	"github.com/ElrondNetwork/elrond-tools-go/elasticreindexer/elastic"
 	"github.com/ElrondNetwork/elrond-tools-go/trieTools/trieToolsCommon"
+	"github.com/ElrondNetwork/elrond-tools-go/trieTools/zeroBalanceSystemAccountChecker/common"
 	sysAccConfig "github.com/ElrondNetwork/elrond-tools-go/trieTools/zeroBalanceSystemAccountChecker/config"
 	"github.com/pelletier/go-toml"
 	"github.com/urfave/cli"
@@ -61,7 +62,7 @@ func startProcess(c *cli.Context) error {
 		return err
 	}
 
-	fh := newOSFileHandler()
+	fh := common.NewOSFileHandler()
 	inputReader, err := newAddressTokensMapFileReader(fh, jsonMarshaller)
 	if err != nil {
 		return err

--- a/trieTools/zeroBalanceSystemAccountChecker/tokensInputReader.go
+++ b/trieTools/zeroBalanceSystemAccountChecker/tokensInputReader.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ElrondNetwork/elrond-go-core/marshal"
 	"github.com/ElrondNetwork/elrond-tools-go/trieTools/trieToolsCommon"
+	"github.com/ElrondNetwork/elrond-tools-go/trieTools/zeroBalanceSystemAccountChecker/common"
 )
 
 const (
@@ -17,12 +18,12 @@ const (
 )
 
 type addressTokensMapFileReader struct {
-	fileHandler fileHandler
+	fileHandler common.FileHandler
 	marshaller  marshal.Marshalizer
 }
 
 func newAddressTokensMapFileReader(
-	fileHandler fileHandler,
+	fileHandler common.FileHandler,
 	marshaller marshal.Marshalizer,
 ) (*addressTokensMapFileReader, error) {
 	if fileHandler == nil {


### PR DESCRIPTION
- Moved `fileHandler.go` and `FileHandler interface` into common place to be used in `metaDataRemoverPackage`
- Refactored `readPemsData` to be a struct with functionality to `readPemsData`
- Added unit test for "happy path" with real data (see `testDataPem/shard0.pem` && `testDataPem/shard1.pem`)