### PR TITLE
En 13127 tool send txs

### DIFF
--- a/tokensRemover/metaDataRemover/mocks/proxy.go
+++ b/tokensRemover/metaDataRemover/mocks/proxy.go
@@ -41,6 +41,7 @@ func (ps *ProxyStub) GetDefaultTransactionArguments(
 	return data.ArgCreateTransaction{}, nil
 }
 
+// SendTransaction -
 func (ps *ProxyStub) SendTransaction(ctx context.Context, tx *data.Transaction) (string, error) {
 	if ps.SendTransactionCalled != nil {
 		return ps.SendTransactionCalled(ctx, tx)
@@ -49,6 +50,7 @@ func (ps *ProxyStub) SendTransaction(ctx context.Context, tx *data.Transaction) 
 	return "", nil
 }
 
+// GetAccount -
 func (ps *ProxyStub) GetAccount(ctx context.Context, address core.AddressHandler) (*data.Account, error) {
 	if ps.GetAccountCalled != nil {
 		return ps.GetAccountCalled(ctx, address)

--- a/tokensRemover/metaDataRemover/mocks/proxy.go
+++ b/tokensRemover/metaDataRemover/mocks/proxy.go
@@ -15,6 +15,8 @@ type ProxyStub struct {
 		address core.AddressHandler,
 		networkConfigs *data.NetworkConfig,
 	) (data.ArgCreateTransaction, error)
+	SendTransactionCalled func(ctx context.Context, tx *data.Transaction) (string, error)
+	GetAccountCalled      func(ctx context.Context, address core.AddressHandler) (*data.Account, error)
 }
 
 // GetNetworkConfig -
@@ -37,4 +39,20 @@ func (ps *ProxyStub) GetDefaultTransactionArguments(
 	}
 
 	return data.ArgCreateTransaction{}, nil
+}
+
+func (ps *ProxyStub) SendTransaction(ctx context.Context, tx *data.Transaction) (string, error) {
+	if ps.SendTransactionCalled != nil {
+		return ps.SendTransactionCalled(ctx, tx)
+	}
+
+	return "", nil
+}
+
+func (ps *ProxyStub) GetAccount(ctx context.Context, address core.AddressHandler) (*data.Account, error) {
+	if ps.GetAccountCalled != nil {
+		return ps.GetAccountCalled(ctx, address)
+	}
+
+	return nil, nil
 }

--- a/tokensRemover/txsSender/config.toml
+++ b/tokensRemover/txsSender/config.toml
@@ -1,2 +1,5 @@
 # Proxy url used to fetch network config + send txs; e.g.: https://gateway.elrond.com for mainnet
 ProxyUrl = ""
+
+# WaitTimeNonceIncremented is the maximum time in seconds to wait between each sent txs to check if the nonce was incremented as expected
+WaitTimeNonceIncremented = 600

--- a/tokensRemover/txsSender/config.toml
+++ b/tokensRemover/txsSender/config.toml
@@ -1,0 +1,2 @@
+# Proxy url used to fetch network config + send txs; e.g.: https://gateway.elrond.com for mainnet
+ProxyUrl = ""

--- a/tokensRemover/txsSender/config/config.go
+++ b/tokensRemover/txsSender/config/config.go
@@ -1,0 +1,6 @@
+package config
+
+// Config holds the config for txs sender tool
+type Config struct {
+	ProxyUrl string `toml:"ProxyUrl"`
+}

--- a/tokensRemover/txsSender/config/config.go
+++ b/tokensRemover/txsSender/config/config.go
@@ -1,6 +1,16 @@
 package config
 
+import "github.com/ElrondNetwork/elrond-tools-go/trieTools/trieToolsCommon"
+
+// ContextFlagsTxsSender is the flags config for txs sender tool
+type ContextFlagsTxsSender struct {
+	trieToolsCommon.ContextFlagsConfig
+	TxsInput   string
+	StartIndex uint64
+}
+
 // Config holds the config for txs sender tool
 type Config struct {
-	ProxyUrl string `toml:"ProxyUrl"`
+	ProxyUrl                 string `toml:"ProxyUrl"`
+	WaitTimeNonceIncremented uint64 `toml:"WaitTimeNonceIncremented"`
 }

--- a/tokensRemover/txsSender/errors.go
+++ b/tokensRemover/txsSender/errors.go
@@ -1,0 +1,7 @@
+package main
+
+import "errors"
+
+var errMaxRetrialsExceeded = errors.New("max retrials exceeded limit")
+
+var errIndexOutOfRange = errors.New("index is out of range")

--- a/tokensRemover/txsSender/flags.go
+++ b/tokensRemover/txsSender/flags.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"github.com/ElrondNetwork/elrond-tools-go/tokensRemover/metaDataRemover/config"
+	"github.com/ElrondNetwork/elrond-tools-go/trieTools/trieToolsCommon"
+	"github.com/urfave/cli"
+)
+
+var (
+	tokens = cli.StringFlag{
+		Name:  "tokens",
+		Usage: "This flag specifies the input file; it expects the input to be a map<shardID, tokens>",
+		Value: "tokens.json",
+	}
+	pems = cli.StringFlag{
+		Name:  "pem",
+		Usage: "This flag specifies pems directory, which should contain multiple pems to be used to sign txs. It expects each pem/shardID to be named shard[ID].pem",
+		Value: "pems",
+	}
+)
+
+func getFlags() []cli.Flag {
+	return []cli.Flag{
+		trieToolsCommon.LogLevel,
+		trieToolsCommon.DisableAnsiColor,
+		trieToolsCommon.LogSaveFile,
+		trieToolsCommon.LogWithLoggerName,
+		trieToolsCommon.ProfileMode,
+		tokens,
+		pems,
+	}
+}
+
+func getFlagsConfig(ctx *cli.Context) config.ContextFlagsMetaDataRemover {
+	flagsConfig := config.ContextFlagsMetaDataRemover{}
+
+	flagsConfig.LogLevel = ctx.GlobalString(trieToolsCommon.LogLevel.Name)
+	flagsConfig.SaveLogFile = ctx.GlobalBool(trieToolsCommon.LogSaveFile.Name)
+	flagsConfig.EnableLogName = ctx.GlobalBool(trieToolsCommon.LogWithLoggerName.Name)
+	flagsConfig.EnablePprof = ctx.GlobalBool(trieToolsCommon.ProfileMode.Name)
+	flagsConfig.Tokens = ctx.GlobalString(tokens.Name)
+	flagsConfig.Pems = ctx.GlobalString(pems.Name)
+
+	return flagsConfig
+}

--- a/tokensRemover/txsSender/flags.go
+++ b/tokensRemover/txsSender/flags.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	input = cli.StringFlag{
-		Name:  "tokens",
+		Name:  "input",
 		Usage: "This flag specifies the input file; it expects the input to be an array of signed txs",
 		Value: "input.json",
 	}

--- a/tokensRemover/txsSender/flags.go
+++ b/tokensRemover/txsSender/flags.go
@@ -1,21 +1,21 @@
 package main
 
 import (
-	"github.com/ElrondNetwork/elrond-tools-go/tokensRemover/metaDataRemover/config"
+	"github.com/ElrondNetwork/elrond-tools-go/tokensRemover/txsSender/config"
 	"github.com/ElrondNetwork/elrond-tools-go/trieTools/trieToolsCommon"
 	"github.com/urfave/cli"
 )
 
 var (
-	tokens = cli.StringFlag{
+	input = cli.StringFlag{
 		Name:  "tokens",
-		Usage: "This flag specifies the input file; it expects the input to be a map<shardID, tokens>",
-		Value: "tokens.json",
+		Usage: "This flag specifies the input file; it expects the input to be an array of signed txs",
+		Value: "input.json",
 	}
-	pems = cli.StringFlag{
-		Name:  "pem",
-		Usage: "This flag specifies pems directory, which should contain multiple pems to be used to sign txs. It expects each pem/shardID to be named shard[ID].pem",
-		Value: "pems",
+	startIndex = cli.Uint64Flag{
+		Name:  "start-index",
+		Usage: "This flag specifies the starting index from txs input array. This tool will start to send txs starting from this index",
+		Value: 0,
 	}
 )
 
@@ -26,20 +26,20 @@ func getFlags() []cli.Flag {
 		trieToolsCommon.LogSaveFile,
 		trieToolsCommon.LogWithLoggerName,
 		trieToolsCommon.ProfileMode,
-		tokens,
-		pems,
+		input,
+		startIndex,
 	}
 }
 
-func getFlagsConfig(ctx *cli.Context) config.ContextFlagsMetaDataRemover {
-	flagsConfig := config.ContextFlagsMetaDataRemover{}
+func getFlagsConfig(ctx *cli.Context) config.ContextFlagsTxsSender {
+	flagsConfig := config.ContextFlagsTxsSender{}
 
 	flagsConfig.LogLevel = ctx.GlobalString(trieToolsCommon.LogLevel.Name)
 	flagsConfig.SaveLogFile = ctx.GlobalBool(trieToolsCommon.LogSaveFile.Name)
 	flagsConfig.EnableLogName = ctx.GlobalBool(trieToolsCommon.LogWithLoggerName.Name)
 	flagsConfig.EnablePprof = ctx.GlobalBool(trieToolsCommon.ProfileMode.Name)
-	flagsConfig.Tokens = ctx.GlobalString(tokens.Name)
-	flagsConfig.Pems = ctx.GlobalString(pems.Name)
+	flagsConfig.TxsInput = ctx.GlobalString(input.Name)
+	flagsConfig.StartIndex = ctx.GlobalUint64(startIndex.Name)
 
 	return flagsConfig
 }

--- a/tokensRemover/txsSender/interface.go
+++ b/tokensRemover/txsSender/interface.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"context"
+
+	"github.com/ElrondNetwork/elrond-sdk-erdgo/core"
+	"github.com/ElrondNetwork/elrond-sdk-erdgo/data"
+)
+
+type proxyProvider interface {
+	GetNetworkConfig(ctx context.Context) (*data.NetworkConfig, error)
+	SendTransaction(ctx context.Context, tx *data.Transaction) (string, error)
+	GetAccount(ctx context.Context, address core.AddressHandler) (*data.Account, error)
+}

--- a/tokensRemover/txsSender/main.go
+++ b/tokensRemover/txsSender/main.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"os"
+
+	logger "github.com/ElrondNetwork/elrond-go-logger"
+	"github.com/ElrondNetwork/elrond-tools-go/trieTools/trieToolsCommon"
+	"github.com/urfave/cli"
+)
+
+const (
+	logFilePrefix   = "txs-sender"
+	tomlFile        = "./config.toml"
+	outputFilePerms = 0644
+)
+
+func main() {
+	app := cli.NewApp()
+	app.Name = "Transaction sender tool"
+	app.Usage = "This is the entry point for the tool that sends one tx/block from multiple shards"
+	app.Flags = getFlags()
+	app.Authors = []cli.Author{
+		{
+			Name:  "The Elrond Team",
+			Email: "contact@elrond.com",
+		},
+	}
+
+	app.Action = func(c *cli.Context) error {
+		return startProcess(c)
+	}
+
+	err := app.Run(os.Args)
+	if err != nil {
+		log.Error(err.Error())
+		os.Exit(1)
+		return
+	}
+}
+
+func startProcess(c *cli.Context) error {
+	flagsConfig := getFlagsConfig(c)
+
+	_, errLogger := trieToolsCommon.AttachFileLogger(log, logFilePrefix, flagsConfig.ContextFlagsConfig)
+	if errLogger != nil {
+		return errLogger
+	}
+
+	err := logger.SetLogLevel(flagsConfig.LogLevel)
+	if err != nil {
+		return err
+	}
+
+	log.Info("starting processing", "pid", os.Getpid())
+
+	return nil
+}

--- a/tokensRemover/txsSender/main.go
+++ b/tokensRemover/txsSender/main.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"io/ioutil"
 	"os"
 
 	logger "github.com/ElrondNetwork/elrond-go-logger"
+	"github.com/ElrondNetwork/elrond-tools-go/tokensRemover/txsSender/config"
 	"github.com/ElrondNetwork/elrond-tools-go/trieTools/trieToolsCommon"
+	"github.com/pelletier/go-toml"
 	"github.com/urfave/cli"
 )
 
@@ -54,4 +57,19 @@ func startProcess(c *cli.Context) error {
 	log.Info("starting processing", "pid", os.Getpid())
 
 	return nil
+}
+
+func loadConfig() (*config.Config, error) {
+	tomlBytes, err := ioutil.ReadFile(tomlFile)
+	if err != nil {
+		return nil, err
+	}
+
+	var cfg config.Config
+	err = toml.Unmarshal(tomlBytes, &cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &cfg, nil
 }

--- a/tokensRemover/txsSender/txsInputReader.go
+++ b/tokensRemover/txsSender/txsInputReader.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/ElrondNetwork/elrond-sdk-erdgo/data"
+)
+
+func readTxsInput(inputFile string) ([]*data.Transaction, error) {
+	workingDir, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+
+	fullPath := filepath.Join(workingDir, inputFile)
+	jsonFile, err := os.Open(fullPath)
+	if err != nil {
+		return nil, err
+	}
+
+	bytesFromJson, err := ioutil.ReadAll(jsonFile)
+	if err != nil {
+		return nil, err
+	}
+
+	txs := make([]*data.Transaction, 0)
+	err = json.Unmarshal(bytesFromJson, &txs)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Info("read from input", "file", inputFile, "num of txs", len(txs))
+	return txs, nil
+}

--- a/tokensRemover/txsSender/txsSender.go
+++ b/tokensRemover/txsSender/txsSender.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ElrondNetwork/elrond-sdk-erdgo/data"
+)
+
+type txsSender struct {
+	proxy proxyProvider
+}
+
+func (ts *txsSender) send(txs []*data.Transaction) error {
+	cfg, err := ts.proxy.GetNetworkConfig(context.Background())
+	if err != nil {
+		return err
+	}
+
+	roundDuration := cfg.RoundDuration
+	log.Info("found", "round duration", roundDuration, "num of txs to send", len(txs))
+	for idx, tx := range txs {
+		err = ts.waitForNonceIncremental(tx.SndAddr, tx.Nonce, 60)
+		if err != nil {
+			log.Error("failed to send tx", "tx index", idx, "error", err)
+			return err
+		}
+
+		hash, err := ts.proxy.SendTransaction(context.Background(), tx)
+		if err != nil {
+			log.Error("failed to send tx", "tx index", idx, "error", err)
+			return err
+		}
+
+		time.Sleep(time.Millisecond * time.Duration(roundDuration))
+		log.Info("sent transaction", "tx hash", hash, "current tx index:", idx, "remaining num of txs", len(txs)-idx-1)
+	}
+
+	return nil
+}
+
+func (ts *txsSender) waitForNonceIncremental(address string, expectedNonce uint64, waitTime uint64) error {
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	for numRetrials := uint64(0); numRetrials < waitTime; <-ticker.C {
+		accountNonce, errNonce := ts.getNonce(address)
+		log.LogIfError(errNonce)
+
+		if accountNonce == expectedNonce {
+			return nil
+		}
+
+		numRetrials++
+	}
+
+	return fmt.Errorf("max retrials exceeded limit of %d seconds", waitTime)
+}
+
+func (ts *txsSender) getNonce(address string) (uint64, error) {
+	addr, err := data.NewAddressFromBech32String(address)
+	if err != nil {
+		return 0, err
+	}
+
+	account, err := ts.proxy.GetAccount(context.Background(), addr)
+	if err != nil {
+		return 0, err
+	}
+
+	return account.Nonce, nil
+}

--- a/tokensRemover/txsSender/txsSender_test.go
+++ b/tokensRemover/txsSender/txsSender_test.go
@@ -13,9 +13,12 @@ import (
 )
 
 func TestTxsSender_SendTxs(t *testing.T) {
+	t.Parallel()
+
 	getAccountCt := 0
 	nonce := uint64(4)
 	currTxIndex := 0
+	roundDuration := int64(100)
 	txs := []*data.Transaction{
 		{
 			Nonce:   nonce,
@@ -29,7 +32,7 @@ func TestTxsSender_SendTxs(t *testing.T) {
 	proxy := &mocks.ProxyStub{
 		GetNetworkConfigCalled: func(ctx context.Context) (*data.NetworkConfig, error) {
 			return &data.NetworkConfig{
-				RoundDuration: 100,
+				RoundDuration: roundDuration,
 			}, nil
 		},
 		GetAccountCalled: func(ctx context.Context, address core.AddressHandler) (*data.Account, error) {
@@ -56,16 +59,192 @@ func TestTxsSender_SendTxs(t *testing.T) {
 	}
 
 	ts := txsSender{
-		proxy: proxy,
+		proxy:                    proxy,
+		waitTimeNonceIncremented: 60,
 	}
 
 	start := time.Now()
-	err := ts.send(txs)
+	err := ts.send(txs, 0)
 	elapsed := time.Since(start)
 
 	require.Nil(t, err)
+	blockTimeWaiting := time.Duration(roundDuration) * time.Millisecond
+	// 2 txs should take > 2*roundDuration time to send, but < ticker time in waitForNonceIncremental, since no retrial is needed
+	require.True(t, elapsed > 2*blockTimeWaiting)
 	require.True(t, elapsed < time.Second)
 	require.Equal(t, 2, getAccountCt)
 	require.Equal(t, 2, currTxIndex)
 	require.Equal(t, uint64(6), nonce)
+}
+
+func TestTxsSender_SendTxsFromIndex(t *testing.T) {
+	t.Parallel()
+
+	getAccountCt := 0
+	sendTxsCt := 0
+	nonce := uint64(4)
+	roundDuration := int64(100)
+	txs := []*data.Transaction{
+		{
+			Nonce:   nonce,
+			SndAddr: "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th",
+		},
+		{
+			Nonce:   nonce + 1,
+			SndAddr: "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th",
+		},
+	}
+	proxy := &mocks.ProxyStub{
+		GetNetworkConfigCalled: func(ctx context.Context) (*data.NetworkConfig, error) {
+			return &data.NetworkConfig{
+				RoundDuration: roundDuration,
+			}, nil
+		},
+		GetAccountCalled: func(ctx context.Context, address core.AddressHandler) (*data.Account, error) {
+			getAccountCt++
+			return &data.Account{Nonce: nonce + 1}, nil
+		},
+		SendTransactionCalled: func(ctx context.Context, tx *data.Transaction) (string, error) {
+			sendTxsCt++
+			require.Equal(t, txs[1], tx)
+			return "txHash", nil
+		},
+	}
+
+	ts := txsSender{
+		proxy:                    proxy,
+		waitTimeNonceIncremented: 60,
+	}
+
+	start := time.Now()
+	err := ts.send(txs, 1)
+	elapsed := time.Since(start)
+
+	require.Nil(t, err)
+	blockTimeWaiting := time.Duration(roundDuration) * time.Millisecond
+	// 1 tx should take > roundDuration time to send, but < 2*roundDuration, since only one out of 2 txs will be sent
+	require.True(t, elapsed > blockTimeWaiting)
+	require.True(t, elapsed < 2*blockTimeWaiting)
+	require.Equal(t, 1, getAccountCt)
+	require.Equal(t, 1, sendTxsCt)
+}
+
+func TestTxsSender_SendTxsAfterRetrials(t *testing.T) {
+	t.Parallel()
+
+	getAccountCt := 0
+	nonce := uint64(4)
+	currTxIndex := 0
+	txs := []*data.Transaction{
+		{
+			Nonce:   nonce,
+			SndAddr: "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th",
+		},
+		{
+			Nonce:   nonce + 1,
+			SndAddr: "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th",
+		},
+	}
+
+	roundDuration := int64(100)
+	proxy := &mocks.ProxyStub{
+		GetNetworkConfigCalled: func(ctx context.Context) (*data.NetworkConfig, error) {
+			return &data.NetworkConfig{
+				RoundDuration: roundDuration,
+			}, nil
+		},
+		GetAccountCalled: func(ctx context.Context, address core.AddressHandler) (*data.Account, error) {
+			getAccountCt++
+
+			localErr := fmt.Errorf("error get account %d", getAccountCt)
+			switch getAccountCt {
+			case 1:
+				return nil, localErr
+			case 2:
+				return nil, localErr
+			case 3, 4:
+				defer func() {
+					nonce++
+				}()
+
+				return &data.Account{Nonce: nonce}, nil
+			default:
+				require.Fail(t, "should not request account anymore")
+			}
+
+			return nil, nil
+		},
+		SendTransactionCalled: func(ctx context.Context, tx *data.Transaction) (string, error) {
+			require.Equal(t, txs[currTxIndex], tx)
+
+			currTxIndex++
+			return fmt.Sprintf("txhash%d", currTxIndex), nil
+		},
+	}
+
+	ts := txsSender{
+		proxy:                    proxy,
+		waitTimeNonceIncremented: 60,
+	}
+
+	start := time.Now()
+	err := ts.send(txs, 0)
+	elapsed := time.Since(start)
+
+	require.Nil(t, err)
+	blockTimeWaiting := time.Duration(roundDuration) * time.Millisecond
+	retrialsTimeWaiting := 2 * time.Second
+	waitTimeDuringExecution := 2*blockTimeWaiting + retrialsTimeWaiting
+	require.True(t, elapsed > waitTimeDuringExecution)
+	require.True(t, elapsed < waitTimeDuringExecution+blockTimeWaiting)
+	require.Equal(t, 4, getAccountCt)
+	require.Equal(t, 2, currTxIndex)
+	require.Equal(t, uint64(6), nonce)
+}
+
+func TestTxsSender_SendTxsFailedAfterWaitingForNonce(t *testing.T) {
+	t.Parallel()
+
+	getAccountCt := 0
+	transactionWasSend := false
+	txs := []*data.Transaction{
+		{
+			Nonce:   0,
+			SndAddr: "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th",
+		},
+	}
+
+	roundDuration := int64(100)
+	proxy := &mocks.ProxyStub{
+		GetNetworkConfigCalled: func(ctx context.Context) (*data.NetworkConfig, error) {
+			return &data.NetworkConfig{
+				RoundDuration: roundDuration,
+			}, nil
+		},
+		GetAccountCalled: func(ctx context.Context, address core.AddressHandler) (*data.Account, error) {
+			getAccountCt++
+			return nil, fmt.Errorf("error get account %d", getAccountCt)
+		},
+		SendTransactionCalled: func(ctx context.Context, tx *data.Transaction) (string, error) {
+			transactionWasSend = true
+			return "", nil
+		},
+	}
+
+	ts := txsSender{
+		proxy:                    proxy,
+		waitTimeNonceIncremented: 2,
+	}
+
+	start := time.Now()
+	err := ts.send(txs, 0)
+	elapsed := time.Since(start)
+
+	require.NotNil(t, err)
+	blockTimeWaiting := time.Duration(roundDuration) * time.Millisecond
+	retrialsTimeWaiting := 2 * time.Second
+	require.True(t, elapsed > retrialsTimeWaiting)
+	require.True(t, elapsed < retrialsTimeWaiting+blockTimeWaiting)
+	require.Equal(t, 2, getAccountCt)
+	require.False(t, transactionWasSend)
 }

--- a/tokensRemover/txsSender/txsSender_test.go
+++ b/tokensRemover/txsSender/txsSender_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/ElrondNetwork/elrond-sdk-erdgo/core"
+	"github.com/ElrondNetwork/elrond-sdk-erdgo/data"
+	"github.com/ElrondNetwork/elrond-tools-go/tokensRemover/metaDataRemover/mocks"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTxsSender_SendTxs(t *testing.T) {
+	getAccountCt := 0
+	nonce := uint64(4)
+	currTxIndex := 0
+	txs := []*data.Transaction{
+		{
+			Nonce:   nonce,
+			SndAddr: "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th",
+		},
+		{
+			Nonce:   nonce + 1,
+			SndAddr: "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th",
+		},
+	}
+	proxy := &mocks.ProxyStub{
+		GetNetworkConfigCalled: func(ctx context.Context) (*data.NetworkConfig, error) {
+			return &data.NetworkConfig{
+				RoundDuration: 100,
+			}, nil
+		},
+		GetAccountCalled: func(ctx context.Context, address core.AddressHandler) (*data.Account, error) {
+			defer func() {
+				getAccountCt++
+				nonce++
+			}()
+
+			switch getAccountCt {
+			case 0, 1:
+				return &data.Account{Nonce: nonce}, nil
+			default:
+				require.Fail(t, "should not request account anymore")
+			}
+
+			return nil, nil
+		},
+		SendTransactionCalled: func(ctx context.Context, tx *data.Transaction) (string, error) {
+			require.Equal(t, txs[currTxIndex], tx)
+
+			currTxIndex++
+			return fmt.Sprintf("txhash%d", currTxIndex), nil
+		},
+	}
+
+	ts := txsSender{
+		proxy: proxy,
+	}
+
+	start := time.Now()
+	err := ts.send(txs)
+	elapsed := time.Since(start)
+
+	require.Nil(t, err)
+	require.True(t, elapsed < time.Second)
+	require.Equal(t, 2, getAccountCt)
+	require.Equal(t, 2, currTxIndex)
+	require.Equal(t, uint64(6), nonce)
+}

--- a/tokensRemover/txsSender/vars.go
+++ b/tokensRemover/txsSender/vars.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	logger "github.com/ElrondNetwork/elrond-go-logger"
+)
+
+var (
+	log = logger.GetOrCreate("main")
+)


### PR DESCRIPTION
- Created tool that sends **already formated and signed** txs from an input json
- Tool will send **one tx/block**
- Before seding any tx, sender nonce will be checked with the tx nonce
- After each sent tx, a log will be printed, e.g.:

`INFO [2022-09-15 13:40:17.204]   sent transaction                         tx hash = 3d44cc40afaba7fe2278f88c4db9da14188bf1269d2f69b157f5e057a1baf4b7 current tx index: = 56 remaining num of txs = 7899 sender nonce = 67 `

Usage
--
`./txsSender --input txsShard0.json`

In case the tool stopped(for w/e reason), let's say at `current tx index: = 56`, it can be restarted starting with the next index:

`./txsSender --input txsShard0.json --start-index 57`

TBD
--
- We can change the above approach so that the tool will save the index in a db. Therefore, whenever the tool is restarted, it will load the last index stored in that db

This tool was tested on devnet successfully : https://devnet-explorer.elrond.com/accounts/erd1l4zf3jhetzynwh5ged032vqulxx2xl0mlw8xq8t6pq8ut88gfgqq84vlvd